### PR TITLE
Slightly relax string match in geocoder test

### DIFF
--- a/src/test/java/org/opentripplanner/geocoder/bano/BanoGeocoderTest.java
+++ b/src/test/java/org/opentripplanner/geocoder/bano/BanoGeocoderTest.java
@@ -27,7 +27,7 @@ public class BanoGeocoderTest {
 
         boolean found = false;
         for (GeocoderResult result : results.getResults()) {
-            if ("55 Rue du Faubourg Saint-Honoré 75008 Paris".equals(result.getDescription())) {
+            if (result.getDescription().contains("55 Rue du Faubourg")) {
                 double dist = SphericalDistanceLibrary.distance(result.getLat(),
                         result.getLng(), 48.870637, 2.316939);
                 assert (dist < 100);

--- a/src/test/java/org/opentripplanner/geocoder/bano/BanoGeocoderTest.java
+++ b/src/test/java/org/opentripplanner/geocoder/bano/BanoGeocoderTest.java
@@ -1,11 +1,15 @@
 package org.opentripplanner.geocoder.bano;
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.geocoder.GeocoderResult;
 import org.opentripplanner.geocoder.GeocoderResults;
 
 import com.vividsolutions.jts.geom.Envelope;
+import java.io.IOException;
+import java.net.URL;
+import java.net.UnknownHostException;
 
 public class BanoGeocoderTest {
 
@@ -14,7 +18,8 @@ public class BanoGeocoderTest {
      * if a network connection is not active or the server is down.
      */
     @Test
-    public void testOnLine() throws Exception {
+    public void testOnLine() throws IOException {
+        assumeConnectedToInternet();
 
         BanoGeocoder banoGeocoder = new BanoGeocoder();
         // The Presidential palace of the French Republic is not supposed to move often
@@ -27,7 +32,7 @@ public class BanoGeocoderTest {
 
         boolean found = false;
         for (GeocoderResult result : results.getResults()) {
-            if (result.getDescription().contains("55 Rue du Faubourg")) {
+            if (result.getDescription().startsWith("55 Rue du Faubourg")) {
                 double dist = SphericalDistanceLibrary.distance(result.getLat(),
                         result.getLng(), 48.870637, 2.316939);
                 assert (dist < 100);
@@ -38,4 +43,11 @@ public class BanoGeocoderTest {
 
     }
 
+    private static void assumeConnectedToInternet() throws IOException {
+        try {
+            new URL("http://www.google.com").openConnection().connect();
+        } catch (UnknownHostException e) {
+            Assume.assumeTrue("Skips tests if not on internet.", false);
+        }
+    }
 }


### PR DESCRIPTION
Fixes a failing test that depends on data from a third-party API that recently changed the output. See https://github.com/opentripplanner/OpenTripPlanner/issues/2798.