### PR TITLE
Add a fix to StreetTransitLink to allow transfers between stops.

### DIFF
--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitLink.java
@@ -70,8 +70,13 @@ public class StreetTransitLink extends Edge {
 
     public State traverse(State s0) {
 
-        // Forbid taking shortcuts composed of two street-transit links in a row. Also avoids spurious leg transitions.
-        if (s0.backEdge instanceof StreetTransitLink) {
+        // Forbid taking shortcuts composed of two street-transit links associated with the same stop in a row. Also
+        // avoids spurious leg transitions. As noted in https://github.com/opentripplanner/OpenTripPlanner/issues/2815,
+        // it is possible that two stops can have the same GPS coordinate thus creating a possibility for a
+        // legitimate StreetTransitLink > StreetTransitLink sequence, so allow two StreetTransitLinks to be taken if
+        // they are for different stops.
+        if (s0.backEdge instanceof StreetTransitLink &&
+            ((StreetTransitLink) s0.backEdge).transitStop == this.transitStop) {
             return null;
         }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitLink.java
@@ -73,8 +73,8 @@ public class StreetTransitLink extends Edge {
         // Forbid taking shortcuts composed of two street-transit links associated with the same stop in a row. Also
         // avoids spurious leg transitions. As noted in https://github.com/opentripplanner/OpenTripPlanner/issues/2815,
         // it is possible that two stops can have the same GPS coordinate thus creating a possibility for a
-        // legitimate StreetTransitLink > StreetTransitLink sequence, so allow two StreetTransitLinks to be taken if
-        // they are for different stops.
+        // legitimate StreetTransitLink > StreetTransitLink sequence, so only forbid two StreetTransitLinks to be taken
+        // if they are for the same stop.
         if (s0.backEdge instanceof StreetTransitLink &&
             ((StreetTransitLink) s0.backEdge).transitStop == this.transitStop) {
             return null;


### PR DESCRIPTION
This PR Fixes #10 by allowing the traversal of two StreetTransit links after another as long as the StreetTransitLinks are for different stops respectively. This allows the creation of SimpleTransfers during the graph build phase and also the proper output of SimpleTransfers in results.