### PR TITLE
Make sure rented cars and vehicles in stateData are properly cloned

### DIFF
--- a/src/main/java/org/opentripplanner/routing/core/StateData.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateData.java
@@ -135,9 +135,13 @@ public class StateData implements Cloneable {
     protected StateData clone() {
         try {
             StateData clonedStateData = (StateData) super.clone();
-            // HashSets do not get cloned quite right, so if any HashSets exists with data that gets added to them
-            // throughout a shortest path search, they must be recreated with the previous state's data in order to make
-            // sure they don't contain data from other paths.
+            // When HashSets (and other collections) are cloned, they contain references to the original HashSet (see
+            // https://stackoverflow.com/a/7537385/269834). Therefore, any Collection in a StateData instance must be
+            // recreated using a copy constructor if data is added to the Collection throughout a shortest path search.
+            // This will then ensure the Collections don't contain data that is specific to a certain path.
+            // For example, the rentedCars and rentedVehicles HashSets are populated with IDs of vehicles that were
+            // rented at some point during a shortest path search. However, other fields like vehicleRentalNetworks are
+            // only set once using data from a StreetEdge and are not added to throughout a shortest path search.
             // See https://github.com/ibi-group/OpenTripPlanner/pull/15 for more discussion.
             clonedStateData.rentedCars = new HashSet<>(this.rentedCars);
             clonedStateData.rentedVehicles = new HashSet<>(this.rentedVehicles);

--- a/src/main/java/org/opentripplanner/routing/core/StateData.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateData.java
@@ -138,6 +138,7 @@ public class StateData implements Cloneable {
             // HashSets do not get cloned quite right, so if any HashSets exists with data that gets added to them
             // throughout a shortest path search, they must be recreated with the previous state's data in order to make
             // sure they don't contain data from other paths.
+            // See https://github.com/ibi-group/OpenTripPlanner/pull/15 for more discussion.
             clonedStateData.rentedCars = new HashSet<>(this.rentedCars);
             clonedStateData.rentedVehicles = new HashSet<>(this.rentedVehicles);
             return clonedStateData;

--- a/src/main/java/org/opentripplanner/routing/core/StateData.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateData.java
@@ -134,7 +134,11 @@ public class StateData implements Cloneable {
 
     protected StateData clone() {
         try {
-            return (StateData) super.clone();
+            StateData clonedStateData = (StateData) super.clone();
+            // hashsets do not get cloned, so they must be created with the existing data
+            clonedStateData.rentedCars = new HashSet<>(this.rentedCars);
+            clonedStateData.rentedVehicles = new HashSet<>(this.rentedVehicles);
+            return clonedStateData;
         } catch (CloneNotSupportedException e1) {
             throw new IllegalStateException("This is not happening");
         }

--- a/src/main/java/org/opentripplanner/routing/core/StateData.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateData.java
@@ -135,7 +135,9 @@ public class StateData implements Cloneable {
     protected StateData clone() {
         try {
             StateData clonedStateData = (StateData) super.clone();
-            // hashsets do not get cloned, so they must be created with the existing data
+            // HashSets do not get cloned quite right, so if any HashSets exists with data that gets added to them
+            // throughout a shortest path search, they must be recreated with the previous state's data in order to make
+            // sure they don't contain data from other paths.
             clonedStateData.rentedCars = new HashSet<>(this.rentedCars);
             clonedStateData.rentedVehicles = new HashSet<>(this.rentedVehicles);
             return clonedStateData;


### PR DESCRIPTION
This fixes a slight problem where the list of already-used rented vehicles and cars were not properly copied into a new HashSet when cloning stateData. This could result in certain cars/vehicles being marked as not rentable in certain branches of the shortest path search when they really should be.