### PR TITLE
Fix setting of back flag when splitting streets

### DIFF
--- a/src/main/java/org/opentripplanner/routing/edgetype/PartialStreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PartialStreetEdge.java
@@ -32,7 +32,7 @@ public class PartialStreetEdge extends StreetWithElevationEdge {
      */
     public PartialStreetEdge(StreetEdge parentEdge, StreetVertex v1, StreetVertex v2,
             LineString geometry, I18NString name, double length) {
-        super(v1, v2, geometry, name, length, parentEdge.getPermission(), false);
+        super(v1, v2, geometry, name, length, parentEdge.getPermission(), parentEdge.isBack());
         this.parentEdge = parentEdge;
 
         // If length is 0, use the provided geometry to estimate it

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -1472,7 +1472,6 @@ public class StreetEdge extends Edge implements Cloneable {
         this.setHasBogusName(other.hasBogusName());
         this.setStairs(other.isStairs());
         this.setWheelchairAccessible(other.isWheelchairAccessible());
-        this.setBack(other.isBack());
         this.setCarNetworks(other.getCarNetworks());
         this.setCarSpeed(other.getCarSpeed());
         this.setFloatingCarDropoffSuitability(other.getFloatingCarDropoffSuitability());


### PR DESCRIPTION
This fix includes [most of the recommended suggestions](https://github.com/opentripplanner/OpenTripPlanner/pull/2791) made by @jwoyame. It corrects the setting of the `back` flag for StreetEdges in order for the geometry to be deserialized properly.

This should fix https://github.com/ibi-group/trimet-mod-otp/issues/243 and also fix https://github.com/ibi-group/trimet-mod-otp/issues/244.