### PR TITLE
Drag as request option

### DIFF
--- a/src/client/js/otp/modules/planner/PlannerModule.js
+++ b/src/client/js/otp/modules/planner/PlannerModule.js
@@ -364,6 +364,7 @@ otp.modules.planner.PlannerModule =
             if(this.showIntermediateStops) queryParams.showIntermediateStops = this.showIntermediateStops;
             if(this.watts) queryParams.watts = this.watts;
             if(this.weight) queryParams.weight = this.weight;
+            if(this.aerodynamicDrag) queryParams.aerodynamicDrag = this.aerodynamicDrag;
             if(this.minimumMicromobilitySpeed) queryParams.minimumMicromobilitySpeed = this.minimumMicromobilitySpeed;
             if(this.maximumMicromobilitySpeed) queryParams.maximumMicromobilitySpeed = this.maximumMicromobilitySpeed;
 

--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -1031,6 +1031,7 @@ otp.widgets.tripoptions.Micromobility =
 
         var html = '<div class="notDraggable">Watts: <input id="'+this.id+'-watts-value" type="text" style="width:30px;" value="250" />';
         html += '<div class="notDraggable">Weight (kg): <input id="'+this.id+'-weight-value" type="text" style="width:30px;" value="105" />';
+        html += '<div class="notDraggable">Aerodynamic Drag (Cd * A): <input id="'+this.id+'-drag-value" type="text" style="width:35px;" value="0.408" />';
         html += '<div class="notDraggable">Min Speed (m/s): <input id="'+this.id+'-minspeed-value" type="text" style="width:30px;" value="0.8" />';
         html += '<div class="notDraggable">Max Speed (m/s): <input id="'+this.id+'-maxspeed-value" type="text" style="width:30px;" value="12.5" />';
         html += "</div>"
@@ -1044,6 +1045,11 @@ otp.widgets.tripoptions.Micromobility =
         $('#'+this.id+'-watts-value').change(function() {
             this_.tripWidget.inputChanged({
                 watts : parseFloat($('#'+this_.id+'-watts-value').val()),
+            });
+        });
+        $('#'+this.id+'-drag-value').change(function() {
+            this_.tripWidget.inputChanged({
+                aerodynamicDrag : parseFloat($('#'+this_.id+'-drag-value').val()),
             });
         });
         $('#'+this.id+'-weight-value').change(function() {
@@ -1071,6 +1077,10 @@ otp.widgets.tripoptions.Micromobility =
         var weightVal = parseFloat(planData.queryParams.weight)
         if(!isNaN(weightVal)) {
             $('#'+this.id+'-weight-value').val(weightVal);
+        }
+        var dragVal = parseFloat(planData.queryParams.aerodynamicDrag)
+        if(!isNaN(dragVal)) {
+         $('#'+this.id+'-drag-value').val(dragVal);
         }
         var minSpeedVal = parseFloat(planData.queryParams.minimumMicromobilitySpeed)
         if(!isNaN(minSpeedVal)) {

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -450,6 +450,27 @@ public abstract class RoutingResource {
     private Double weight;
 
     /**
+     * This is coefficient of drag and frontal area multiplied together. The equation for drag resistance and the
+     * extracted value is as follows:
+     *
+     * Fdrag = 0.5 * Cd * A * Rho * V^2
+     *               ⎣CdA_⎦
+     *
+     * See https://www.gribble.org/cycling/power_v_speed.html
+     *
+     * where
+     * Cd = coefficient of drag
+     * A = frontal area in m^2
+     * Rho = air density in kg / m^3
+     *
+     * You need a wind tunnel to properly measure the overall interaction of the coefficient of drag and frontal area,
+     * but a study showed that a comfortable bicycling position had a Cd * A value of 0.408.
+     * See https://www.cyclingpowerlab.com/CyclingAerodynamics.aspx
+     */
+    @QueryParam("aerodynamicDrag")
+    private Double aerodynamicDrag;
+
+    /**
      * The minimum speed of a personal micromobility vehicle. This should only be used to avoid unreasonably slow times
      * on hills. If it is desired to model effectively impossible travel uphill (ie the vehicle can't reasonably be
      * transported up a steep enough grade) enter 0. Value in m/s. If this parameter is not provided, a default of
@@ -817,6 +838,9 @@ public abstract class RoutingResource {
 
         if (weight != null)
             request.weight = weight;
+
+        if (aerodynamicDrag != null)
+            request.aerodynamicDrag = aerodynamicDrag;
 
         if (minimumMicromobilitySpeed != null)
             request.minimumMicromobilitySpeed = minimumMicromobilitySpeed;

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -590,6 +590,26 @@ public class RoutingRequest implements Cloneable, Serializable {
      */
     public double weight = 105;
 
+    /**
+     * This is coefficient of drag and frontal area multiplied together. The equation for drag resistance and the
+     * extracted value is as follows:
+     *
+     * Fdrag = 0.5 * Cd * A * Rho * V^2
+     *               ⎣CdA_⎦
+     *
+     * See https://www.gribble.org/cycling/power_v_speed.html
+     *
+     * where
+     * Cd = coefficient of drag
+     * A = frontal area in m^2
+     * Rho = air density in kg / m^3
+     *
+     * You need a wind tunnel to properly measure the overall interaction of the coefficient of drag and frontal area,
+     * but a study showed that a comfortable bicycling position had a Cd * A value of 0.408.
+     * See https://www.cyclingpowerlab.com/CyclingAerodynamics.aspx
+     */
+    public double aerodynamicDrag = 0.408;
+
     /** Saves split edge which can be split on origin/destination search
      *
      * This is used so that TrivialPathException is thrown if origin and destination search would split the same edge

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -1023,26 +1023,28 @@ public class StreetEdge extends Edge implements Cloneable {
             weight *
             // These cosine and sine calculations could be precalculated during graph build
             (coefficientOfRollingResistance * Math.cos(beta) + Math.sin(beta));
+        // The interaction of aerodynamics and air density (Cd * A * p)
+        double dragResistance = aerodynamicDrag * airDensity;
 
         double a = (
             -Math.pow(dynamicRollingResistance, 3) / 27.0
         ) + (
             (2.0 * normalizedRollingFriction * dynamicRollingResistance) /
-                (3.0 * aerodynamicDrag * Math.pow(airDensity, 2))
+                (3.0 * Math.pow(dragResistance, 2))
         ) + (
-            watts / (aerodynamicDrag * airDensity)
+            watts / (dragResistance)
         );
         double b = (
-            2.0 / (9.0 * aerodynamicDrag * airDensity)
+            2.0 / (9.0 * dragResistance)
         ) * (
             3.0 * normalizedRollingFriction -
                 (
-                    (2.0 * dynamicRollingResistance) / (aerodynamicDrag * airDensity)
+                    (2.0 * dynamicRollingResistance) / (dragResistance)
                 )
         );
 
         double cardanicCheck = Math.pow(a, 2) + Math.pow(b, 3);
-        double rollingDragComponent = 2.0 / 3.0 * dynamicRollingResistance / (aerodynamicDrag * airDensity);
+        double rollingDragComponent = 2.0 / 3.0 * dynamicRollingResistance / (dragResistance);
         double speed;
         if (cardanicCheck >= 0) {
             double cardanicCheckSqrt = Math.sqrt(cardanicCheck);

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -894,7 +894,8 @@ public class StreetEdge extends Edge implements Cloneable {
                     options.weight,
                     Math.atan(0), // 0 slope beta
                     getRollingResistanceCoefficient(),
-                    ElevationUtils.ZERO_ELEVATION_DRAG_RESISTIVE_FORCE_COMPONENT,
+                    options.aerodynamicDrag,
+                    ElevationUtils.ZERO_ELEVATION_AIR_DENSITY,
                     options.minimumMicromobilitySpeed,
                     options.maximumMicromobilitySpeed
                 ),
@@ -980,8 +981,7 @@ public class StreetEdge extends Edge implements Cloneable {
      *              difficulty of traveling over bumpy roadways. This value is used to calculate the value of `Frg` as
      *              noted in the above equations.See this wikipedia page for a list of coefficients by various surface
      *              types: https://en.wikipedia.org/wiki/Rolling_resistance#Rolling_resistance_coefficient_examples
-     * @param aerodynamicDragComponent The product of the coefficient of aerodynamic drag, frontal area and air density.
-     *              This value is product of (Cd * A * ρ) as noted in the above mathematical equations.
+     * @param airDensity The air density .
      * @param minSpeed The minimum speed that the micromobility should travel at in cases where the slope is so steep
      *              that it would be faster to walk with the vehicle.
      * @param maxSpeed The maximum speed the vehicle can travel at.
@@ -992,7 +992,8 @@ public class StreetEdge extends Edge implements Cloneable {
         double weight,
         double beta,
         double coefficientOfRollingResistance,
-        double aerodynamicDragComponent,
+        double aerodynamicDrag,
+        double airDensity,
         double minSpeed,
         double maxSpeed
     ) {
@@ -1027,21 +1028,21 @@ public class StreetEdge extends Edge implements Cloneable {
             -Math.pow(dynamicRollingResistance, 3) / 27.0
         ) + (
             (2.0 * normalizedRollingFriction * dynamicRollingResistance) /
-                (3.0 * Math.pow(aerodynamicDragComponent, 2))
+                (3.0 * aerodynamicDrag * Math.pow(airDensity, 2))
         ) + (
-            watts / aerodynamicDragComponent
+            watts / (aerodynamicDrag * airDensity)
         );
         double b = (
-            2.0 / (9.0 * aerodynamicDragComponent)
+            2.0 / (9.0 * aerodynamicDrag * airDensity)
         ) * (
             3.0 * normalizedRollingFriction -
                 (
-                    (2.0 * dynamicRollingResistance) / aerodynamicDragComponent
+                    (2.0 * dynamicRollingResistance) / (aerodynamicDrag * airDensity)
                 )
         );
 
         double cardanicCheck = Math.pow(a, 2) + Math.pow(b, 3);
-        double rollingDragComponent = 2.0 / 3.0 * dynamicRollingResistance / aerodynamicDragComponent;
+        double rollingDragComponent = 2.0 / 3.0 * dynamicRollingResistance / (aerodynamicDrag * airDensity);
         double speed;
         if (cardanicCheck >= 0) {
             double cardanicCheckSqrt = Math.sqrt(cardanicCheck);

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetWithElevationEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetWithElevationEdge.java
@@ -37,12 +37,12 @@ public class StreetWithElevationEdge extends StreetEdge {
     // an array of the length in meters of the corresponding gradient at the same index
     private short[] gradientLengths;
 
-    // The maximum resistive drag force component along this StreetWithElevationEdge. The difference of this resistive
-    // drag force component is likely extremely small along the vast majority of edges in the graph. Therefore, don't
-    // store all values in an array like the gradients and gradient lengths. Instead, use the maximum resistive drag
-    // component which would correspond to drag resistive force at the minimum altitude seen on this edge. This is an
-    // overestimate of aerodynamic drag.
-    private double maximumDragResistiveForceComponent;
+    // The maximum air density seen along this StreetWithElevationEdge. The difference of this resistive drag force
+    // component is likely extremely small along the vast majority of edges in the graph. Therefore, don't store all
+    // values in an array like the gradients and gradient lengths. Instead, use the maximum air density which would
+    // correspond to the air density observed at the minimum altitude seen on this edge. This is an overestimate of air
+    // density.
+    private double maximumAirDensity;
 
     public StreetWithElevationEdge(StreetVertex v1, StreetVertex v2, LineString geometry,
             I18NString name, double length, StreetTraversalPermission permission, boolean back) {
@@ -80,7 +80,7 @@ public class StreetWithElevationEdge extends StreetEdge {
 
         gradients = costs.gradients;
         gradientLengths = costs.gradientLengths;
-        maximumDragResistiveForceComponent = costs.maximumDragResistiveForceComponent;
+        maximumAirDensity = costs.maximumAirDensity;
 
         return costs.flattened;
     }
@@ -143,7 +143,8 @@ public class StreetWithElevationEdge extends StreetEdge {
                     options.weight,
                     Math.atan(gradients[i] / 100.0),
                     this.getRollingResistanceCoefficient(),
-                    maximumDragResistiveForceComponent,
+                    options.aerodynamicDrag,
+                    maximumAirDensity,
                     options.minimumMicromobilitySpeed,
                     options.maximumMicromobilitySpeed
                 ),

--- a/src/main/java/org/opentripplanner/routing/util/SlopeCosts.java
+++ b/src/main/java/org/opentripplanner/routing/util/SlopeCosts.java
@@ -9,11 +9,11 @@ public class SlopeCosts {
     public final double lengthMultiplier; // Multiplier to get true length based on flat (projected) length
     public final byte[] gradients; // array of gradients as percents
     public final short[] gradientLengths; // array of the length of each gradient in meters
-    public final double maximumDragResistiveForceComponent; // the maximum resistive drag force component along an edge
+    public final double maximumAirDensity; // the maximum resistive drag force component along an edge
 
     public SlopeCosts(double slopeSpeedFactor, double slopeWorkFactor, double slopeSafetyCost,
                       double maxSlope, double lengthMultiplier, boolean flattened, byte[] gradients,
-                      short[] gradientLengths, double maximumDragResistiveForceComponent) {
+                      short[] gradientLengths, double maximumAirDensity) {
         this.slopeSpeedFactor = slopeSpeedFactor;
         this.slopeWorkFactor = slopeWorkFactor;
         this.slopeSafetyCost = slopeSafetyCost;
@@ -22,6 +22,6 @@ public class SlopeCosts {
         this.flattened = flattened;
         this.gradients = gradients;
         this.gradientLengths = gradientLengths;
-        this.maximumDragResistiveForceComponent = maximumDragResistiveForceComponent;
+        this.maximumAirDensity = maximumAirDensity;
     }
 }

--- a/src/test/java/org/opentripplanner/routing/edgetype/MicromobilityTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/MicromobilityTest.java
@@ -5,18 +5,19 @@ import org.opentripplanner.routing.util.ElevationUtils;
 
 public class MicromobilityTest extends TestCase {
 
-    public void testDragResistiveComponent () {
+    public void testAirDensityComponent() {
         double allowableDelta = 0.0001;
 
         // elevation at sea level
-        assertEquals(0.4553, ElevationUtils.getDragResistiveForceComponent(0), allowableDelta);
+        assertEquals(1.2047, ElevationUtils.getAirDensity(0), allowableDelta);
 
         // elevation at 2,000 meters
-        assertEquals(0.3801, ElevationUtils.getDragResistiveForceComponent(2000), allowableDelta);
+        assertEquals(1.0055, ElevationUtils.getAirDensity(2000), allowableDelta);
     }
 
     public static final double powerReductionFactor = 0.8; // used to make it easier to reason about specific power inputs
     public static final double allowableSpeedDelta = 0.1;
+    public static final double aerodynamicDrag = 0.63 * 0.6;
 
     public void testMicromobilityTravelTimeAtZeroSlope () {
         assertEquals(
@@ -26,7 +27,8 @@ public class MicromobilityTest extends TestCase {
                 105,
                 Math.atan(0),
                 0.005,
-                ElevationUtils.ZERO_ELEVATION_DRAG_RESISTIVE_FORCE_COMPONENT,
+                aerodynamicDrag,
+                ElevationUtils.ZERO_ELEVATION_AIR_DENSITY,
                 Double.NEGATIVE_INFINITY, // an obscene number to make sure min speed bounding is turned off
                 Double.POSITIVE_INFINITY // an obscene number to make sure max speed bounding is turned off
             ),
@@ -42,7 +44,8 @@ public class MicromobilityTest extends TestCase {
                 105,
                 Math.atan(0.07),
                 0.005,
-                ElevationUtils.ZERO_ELEVATION_DRAG_RESISTIVE_FORCE_COMPONENT,
+                aerodynamicDrag,
+                ElevationUtils.ZERO_ELEVATION_AIR_DENSITY,
                 Double.NEGATIVE_INFINITY, // an obscene number to make sure min speed bounding is turned off
                 Double.POSITIVE_INFINITY // an obscene number to make sure max speed bounding is turned off
             ),
@@ -58,7 +61,8 @@ public class MicromobilityTest extends TestCase {
                 105,
                 Math.atan(-0.05),
                 0.005,
-                ElevationUtils.ZERO_ELEVATION_DRAG_RESISTIVE_FORCE_COMPONENT,
+                aerodynamicDrag,
+                ElevationUtils.ZERO_ELEVATION_AIR_DENSITY,
                 Double.NEGATIVE_INFINITY, // an obscene number to make sure min speed bounding is turned off
                 Double.POSITIVE_INFINITY // an obscene number to make sure max speed bounding is turned off
             ),
@@ -74,7 +78,8 @@ public class MicromobilityTest extends TestCase {
                 105,
                 Math.atan(0.2),
                 0.005,
-                ElevationUtils.ZERO_ELEVATION_DRAG_RESISTIVE_FORCE_COMPONENT,
+                aerodynamicDrag,
+                ElevationUtils.ZERO_ELEVATION_AIR_DENSITY,
                 0.8, // minimum speed in m/s
                 Double.POSITIVE_INFINITY // an obscene number to make sure max speed bounding is turned off
             ),
@@ -90,7 +95,8 @@ public class MicromobilityTest extends TestCase {
                 105,
                 Math.atan(-0.2),
                 0.005,
-                ElevationUtils.ZERO_ELEVATION_DRAG_RESISTIVE_FORCE_COMPONENT,
+                aerodynamicDrag,
+                ElevationUtils.ZERO_ELEVATION_AIR_DENSITY,
                 Double.NEGATIVE_INFINITY, // an obscene number to make sure min speed bounding is turned off
                 12.5 // maximum speed in m/s
             ),


### PR DESCRIPTION
This refactor enables reqeusts to have inputs of the aerodynamic drag for a calculation with Micromobility travel. Since a particular user can change their position to a more-or-less aerodynamic position and certain vehicles may be more aerodynamic than others it makes sense to allow this value to be dynamically set in each request. Notes on where to find certain verified values of Cd * A are noted in the comments.