### PR TITLE
Add No API TNC updater

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -413,7 +413,7 @@ The complete list of modes are:
 
 - `CAR_HAIL`: Hailing a car from a transportation network company such as Lyft or Uber and then riding in the vehicle for part or the entirety of the route. OTP will still use its underlying graph to calculate driving directions, so car leg results will likely contain different travel time estimates than those quoted from the TNC providers. If service is not available at a particular pickup location, this can cause a TNC availability error which can result in an itinerary not being able to be calculated.
 
-    _Prerequisite:_ API keys for the respective TNC providers must be added in `router-config.json`.
+    _Prerequisite:_ At least one TNC updater must be added in `router-config.json`.
 
 - `MICROMOBILITY`: Riding on a lightweight motorized vehicle for the entirety of the route or taking said vehicle onto public transport and riding again from the arrival station to the destination. This mode could theoretically also be used to model human power while pedaling a bicycle.
 
@@ -714,11 +714,32 @@ url: the URL of the GBFS feed (do not include the gbfs.json at the end) *
 ```
 \* For a list of known GBFS feeds see the [list of known GBFS feeds](https://github.com/NABSA/gbfs/blob/master/systems.csv)
 
-#### TNC Configuration
+#### Transportation Network Company Configuration
 
-It is possible to add either Uber or Lyft as a TNC updater, assuming that either of those companies allow you to access their APIs. OTP provides helper methods for making authenticated requests to each provider's API and also for verifying that TNC service exists when making certain routing requests that use a TNC for part or all of the trip.
+A transportation network company (TNC) is a company that provides on-demand car hailing services. When one of these updaters is configured it is possible to plan trips where part or all of the journey involves a passenger being picked up, transported in a car and then dropped off at another location.
+
+A TNC updater can be configured with either a company that has an API for determining arrival and ride estimates, or with a simple "No API" updater that always returns a default arrival estimate and 0 duration and $0 ride estimates.
+
+For the TNC updaters with APIs, it is possible to add either Uber or Lyft as a TNC updater, assuming that either of those companies allow you to access their APIs. OTP provides helper methods for making authenticated requests to each provider's API and also for verifying that TNC service exists when making certain routing requests that use a TNC for part or all of the trip.
 
 For each TNC updater, you have to manually determine what the ride type ids are for wheelchair-accessible services in the area that OTP will be planning trips in.
+
+##### No API
+
+- Add one entry in the `updater` field of `router-config.json` in the format:
+
+```JSON
+{
+    "type": "transportation-network-company-updater",
+    "sourceType": "no-api",
+    "defaultArrivalTimeSeconds": 123,
+    "isWheelChairAccessible": true
+}
+```
+
+If the `defaultArrivalTimeSeconds` is set in the config, this value will always be returned as the default arrival estimate. Otherwise, a default arrival estimate of 0 seconds is used.
+
+If the `isWheelChairAccessible` is set to true, then the arrival and ride estimates will show that the ride type of the TNC allows wheelchairs.
 
 ##### Uber
 

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -733,7 +733,7 @@ public abstract class RoutingResource {
         // first TNC before transit.  (See StateEditor.boardHailedCar)
         if (this.modes != null && this.modes.qModes.contains(new QualifiedMode("CAR_HAIL"))) {
             if (companies == null) {
-                throw new ParameterException(Message.TRANSPORTATION_NETWORK_COMPANY_REQUEST_INVALID);
+                companies = "NOAPI";    
             }
 
             request.companies = companies;

--- a/src/main/java/org/opentripplanner/routing/transportation_network_company/TransportationNetworkCompany.java
+++ b/src/main/java/org/opentripplanner/routing/transportation_network_company/TransportationNetworkCompany.java
@@ -14,5 +14,5 @@
 package org.opentripplanner.routing.transportation_network_company;
 
 public enum TransportationNetworkCompany {
-    LYFT, UBER
+    LYFT, NOAPI, UBER;
 }

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/NoApiTransportationNetworkCompanyDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/NoApiTransportationNetworkCompanyDataSource.java
@@ -36,6 +36,7 @@ public class NoApiTransportationNetworkCompanyDataSource extends TransportationN
      */
     public NoApiTransportationNetworkCompanyDataSource(JsonNode config) {
         defaultArrivalTimeSeconds = config.path("defaultArrivalTimeSeconds").asInt();
+        isWheelChairAccessible = config.path("isWheelChairAccessible").asBoolean();
     }
 
     /**

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/NoApiTransportationNetworkCompanyDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/NoApiTransportationNetworkCompanyDataSource.java
@@ -42,9 +42,9 @@ public class NoApiTransportationNetworkCompanyDataSource extends TransportationN
     /**
      * For testing purposes only.
      */
-    public NoApiTransportationNetworkCompanyDataSource() {
-        defaultArrivalTimeSeconds = 123;
-        isWheelChairAccessible = true;
+    public NoApiTransportationNetworkCompanyDataSource(int defaultArrivalTimeSeconds, boolean isWheelChairAccessible) {
+        this.defaultArrivalTimeSeconds = defaultArrivalTimeSeconds;
+        this.isWheelChairAccessible = isWheelChairAccessible;
     }
 
     @Override public TransportationNetworkCompany getTransportationNetworkCompanyType() {
@@ -53,8 +53,8 @@ public class NoApiTransportationNetworkCompanyDataSource extends TransportationN
 
     /**
      * In lieu of making an API request, this will merely return a single arrival estimate with the default arrive time.
-     * An idea for improvement of this could be to add the ability to parse GeoJSON representing the service area of
-     * the TNC provider in order to be able to determine if TNC service is unavailable at the given position.
+     * TODO: add the ability to parse GeoJSON representing the service area of the TNC provider in order to be able to
+     *  determine if TNC service is unavailable at the given position.
      */
     @Override protected List<ArrivalTime> queryArrivalTimes(Position position) throws IOException {
         List arrivalEstimates = new ArrayList();

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/NoApiTransportationNetworkCompanyDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/NoApiTransportationNetworkCompanyDataSource.java
@@ -1,0 +1,88 @@
+package org.opentripplanner.updater.transportation_network_company;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.opentripplanner.routing.transportation_network_company.ArrivalTime;
+import org.opentripplanner.routing.transportation_network_company.RideEstimate;
+import org.opentripplanner.routing.transportation_network_company.TransportationNetworkCompany;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This data source is to model a transportation network company for which no API exists to calculate real-time arrival
+ * estimates or ride estimates. The config for this updater can include a default value for the estimated arrival time
+ * which will always be provided when estimates for the arrival time are desired.
+ */
+public class NoApiTransportationNetworkCompanyDataSource extends TransportationNetworkCompanyDataSource {
+    private static final Logger LOG = LoggerFactory.getLogger(NoApiTransportationNetworkCompanyDataSource.class);
+
+    /**
+     * The default arrival time in seconds to respond with for all valid arrival time estimate requests. Defaults to 0.
+     */
+    private int defaultArrivalTimeSeconds = 0;
+
+    /**
+     * Whether or not the TNC service being modeled is wheelchair accessible. Defaults to false.
+     */
+    private boolean isWheelChairAccessible = false;
+
+    /**
+     * Configures the data source. At this point, the only values the config could contain are the following:
+     * - defaultArrivalTimeSeconds
+     * - isWheelChairAccessible
+     */
+    public NoApiTransportationNetworkCompanyDataSource(JsonNode config) {
+        defaultArrivalTimeSeconds = config.path("defaultArrivalTimeSeconds").asInt();
+    }
+
+    /**
+     * For testing purposes only.
+     */
+    public NoApiTransportationNetworkCompanyDataSource() {
+        defaultArrivalTimeSeconds = 123;
+        isWheelChairAccessible = true;
+    }
+
+    @Override public TransportationNetworkCompany getTransportationNetworkCompanyType() {
+        return TransportationNetworkCompany.NOAPI;
+    }
+
+    /**
+     * In lieu of making an API request, this will merely return a single arrival estimate with the default arrive time.
+     * An idea for improvement of this could be to add the ability to parse GeoJSON representing the service area of
+     * the TNC provider in order to be able to determine if TNC service is unavailable at the given position.
+     */
+    @Override protected List<ArrivalTime> queryArrivalTimes(Position position) throws IOException {
+        List arrivalEstimates = new ArrayList();
+        arrivalEstimates.add(new ArrivalTime(
+            TransportationNetworkCompany.NOAPI,
+            "no-api-tnc-service",
+            "no-api-tnc-service",
+            defaultArrivalTimeSeconds,
+            isWheelChairAccessible
+
+        ));
+        return arrivalEstimates;
+    }
+
+    /**
+     * In lieu of making an API request, this will merely return a single ride estimate with 0 duration and cost, but
+     * with the wheelchair accessibility type that is possibly defined in the config.
+     */
+    @Override protected List<RideEstimate> queryRideEstimates(RideEstimateRequest request) throws IOException {
+        List rideEstimates = new ArrayList();
+        rideEstimates.add(new RideEstimate(
+            TransportationNetworkCompany.NOAPI,
+            "undefined",
+            0,
+            0,
+            0,
+            "no-api-tnc-service",
+            isWheelChairAccessible
+        ));
+        return rideEstimates;
+    }
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/TransportationNetworkCompanyUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/TransportationNetworkCompanyUpdater.java
@@ -59,6 +59,8 @@ public class TransportationNetworkCompanyUpdater implements GraphUpdater {
                 source = new UberTransportationNetworkCompanyDataSource(config);
             } else if (sourceType.equals("lyft")) {
                 source = new LyftTransportationNetworkCompanyDataSource(config);
+            } else if (sourceType.equals("no-api")) {
+                source = new NoApiTransportationNetworkCompanyDataSource(config);
             }
         }
 

--- a/src/test/java/org/opentripplanner/updater/transportation_network_company/NoApiTransportationNetworkCompanyDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/transportation_network_company/NoApiTransportationNetworkCompanyDataSourceTest.java
@@ -1,0 +1,60 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company;
+
+import org.junit.Test;
+import org.opentripplanner.routing.transportation_network_company.ArrivalTime;
+import org.opentripplanner.routing.transportation_network_company.RideEstimate;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class NoApiTransportationNetworkCompanyDataSourceTest {
+
+    private static NoApiTransportationNetworkCompanyDataSource source = new NoApiTransportationNetworkCompanyDataSource();
+
+    @Test
+    public void testGetArrivalTimes () throws IOException, ExecutionException {
+        List<ArrivalTime> arrivalTimes = source.getArrivalTimes(1.2, 3.4);
+
+        assertEquals(arrivalTimes.size(),  1);
+        ArrivalTime arrival = arrivalTimes.get(0);
+        assertEquals("no-api-tnc-service", arrival.displayName);
+        assertEquals("no-api-tnc-service", arrival.productId);
+        assertEquals(123, arrival.estimatedSeconds);
+        assertEquals(true, arrival.wheelchairAccessible);
+    }
+
+    @Test
+    public void testGetEstimatedRideTime () throws IOException, ExecutionException {
+        List<RideEstimate> rideEstimates = source.getRideEstimates(
+            1.2,
+            3.4,
+            1.201,
+            3.401
+        );
+
+        assertEquals(rideEstimates.size(), 1);
+        RideEstimate rideEstimate = rideEstimates.get(0);
+        assertEquals("no-api-tnc-service", rideEstimate.rideType);
+        assertEquals(0, rideEstimate.duration);
+        assertEquals(0, rideEstimate.minCost, 0.001);
+        assertEquals(0, rideEstimate.maxCost, 0.001);
+        assertEquals(true, rideEstimate.wheelchairAccessible);
+    }
+}

--- a/src/test/java/org/opentripplanner/updater/transportation_network_company/NoApiTransportationNetworkCompanyDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/transportation_network_company/NoApiTransportationNetworkCompanyDataSourceTest.java
@@ -26,7 +26,10 @@ import static org.junit.Assert.assertNotNull;
 
 public class NoApiTransportationNetworkCompanyDataSourceTest {
 
-    private static NoApiTransportationNetworkCompanyDataSource source = new NoApiTransportationNetworkCompanyDataSource();
+    private static NoApiTransportationNetworkCompanyDataSource source = new NoApiTransportationNetworkCompanyDataSource(
+        123,
+        true
+    );
 
     @Test
     public void testGetArrivalTimes () throws IOException, ExecutionException {


### PR DESCRIPTION
This PR adds the ability to model a TNC provider that doesn't have an API. This feature was requested so that it would be possible to do testing of https://github.com/opentripplanner/OpenTripPlanner/pull/2678 without a possibly unobtainable API key.

To try this out, run OTP with a router-config.json file with the following contents:

```json
// router-config.json
{
    "updaters": [
        { // TNC feed
            "type": "transportation-network-company-updater",
            "sourceType": "no-api"
        }
    ]
}
```