### PR TITLE
Elevation improvements

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -225,7 +225,7 @@ Calculating elevations on all StreetEdges can take a dramatically long time. In 
 
 If you are using cloud computing for your OTP instances, it is recommended to create prebuilt images that contain the elevation data you need. This will save time because all of the data won't need to be downloaded.
 
-However, the bulk of the time will still spent calculating elevations for all of the street edges. Therefore, a further optimazation can be done to calculate and save the elevation data during a graph build and then save it for future use.
+However, the bulk of the time will still be spent calculating elevations for all of the street edges. Therefore, a further optimization can be done to calculate and save the elevation data during a graph build and then save it for future use.
 
 In order to write out the precalculated elevation data, add this to your `build-config.json` file:
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -198,6 +198,29 @@ You can configure it as follows in `build-config.json`:
 }
 ```
 
+### Geoid Difference
+
+With some elevation data, the elevation values are specified as relative to the a geoid (irregular estimate of mean sea level). See [issue #2301](https://github.com/opentripplanner/OpenTripPlanner/issues/2301) for detailed discussion of this. In this cases, it is necessary to also add this geoid value onto the elevation value to get the correct result. OTP can automatically calculate these values in one of two ways. 
+
+The first way is to use the geoid difference value that is calculated once at the center of the graph. This value is returned in each trip plan response in the [ElevationMetadata](http://otp-docs.ibi-transit.com/api/json_ElevationMetadata.html) field. Using a single value can be sufficient for smaller OTP deployments, but might result in incorrect values at the edges of larger OTP deployments. If your OTP instance uses this, it is recommended to set a default request value in the `router-config.json` file as follows:
+
+```JSON
+// router-config.json
+{
+    "routingDefaults": {
+        "geoidElevation ": true   
+    }
+}
+```
+
+The second way is to precompute these geoid difference values at a more granular level and include them when calculating elevations for each sampled point along each street edge. In order to speed up calculations, the geoid difference values are calculated and cached using only 2 significant digits of GPS coordinates. This is more than enough detail for most regions of the world and should result in less than one meter of difference in areas that have large changes in geoid difference values. To enable this, include the following in the `build-config.json` file: 
+
+```JSON
+// build-config.json
+{
+  "includeEllipsoidToGeoidDifference": true
+}
+```
 
 ### Other raster elevation data
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -222,6 +222,8 @@ The second way is to precompute these geoid difference values at a more granular
 }
 ```
 
+If the geoid difference values are precomputed, be careful to not set the routing resource value of `geoidElevation` to true in order to avoid having the graph-wide geoid added again to all elevation values in the relevant street edges in responses.
+
 ### Other raster elevation data
 
 For other parts of the world you will need a GeoTIFF file containing the elevation data. These are often available from

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -84,7 +84,8 @@ config key | description | value type | value default | notes
 `matchBusRoutesToStreets` | Based on GTFS shape data, guess which OSM streets each bus runs on to improve stop linking | boolean | false |
 `fetchElevationUS` | Download US NED elevation data and apply it to the graph | boolean | false |
 `elevationBucket` | If specified, download NED elevation tiles from the given AWS S3 bucket | object | null | provide an object with `accessKey`, `secretKey`, and `bucketName` for AWS S3
-`elevationUnitMultiplier` | Specify a multiplier to convert elevation units from source to meters | double | 1.0 | see [Elevation unit conversion](#elevation-unit-conversion)
+`readCachedElevations` | If true, reads in pre-calculated elevation data. | boolean | true | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
+`writeCachedElevations` | If true, writes the calculated elevation data. | boolean | false | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
 `fares` | A specific fares service to use | object | null | see [fares configuration](#fares-configuration)
 `osmNaming` | A custom OSM namer to use | object | null | see [custom naming](#custom-naming)
 `osmWayPropertySet` | Custom OSM way properties | string | `default` | options: `default`, `norway`
@@ -218,6 +219,28 @@ order as the above-mentioned SRTM data, which is also the default for the popula
 DEM files(USGS DEM) is not supported by OTP, but can be converted to GeoTIFF with tools like [GDAL](http://www.gdal.org/). 
 Use `gdal_merge.py -o merged.tiff *.dem` to merge a set of `dem` files into one `tif` file.
 
+### Elevation Data Calculation Optimizations
+
+Calculating elevations on all StreetEdges can take a dramatically long time. In a very large graph build for multiple Northeast US states, the time it took to download the elevation data and calculate all of the elevations took 5,509 seconds (roughly 1.5 hours).
+
+If you are using cloud computing for your OTP instances, it is recommended to create prebuilt images that contain the elevation data you need. This will save time because all of the data won't need to be downloaded.
+
+However, the bulk of the time will still spent calculating elevations for all of the street edges. Therefore, a further optimazation can be done to calculate and save the elevation data during a graph build and then save it for future use.
+
+In order to write out the precalculated elevation data, add this to your `build-config.json` file:
+
+```JSON
+// build-config.json
+{
+  "writeCachedElevations": true
+}
+```
+
+After building the graph, a file called `cached_elevations.obj` will be written to the cache directory. By default, this file is not written during graph builds. There is also a graph build parameter called `readCachedElevations` which is set to `true` by default.
+
+In graph builds, the elevation module will attempt to read the `cached_elevations.obj` file from the cache directory. The cache directory defaults to `/var/otp/cache`, but this can be overriden via the CLI argument `--cache <directory>`. For the same graph build for multiple Northeast US states, the time it took with using this predownloaded and precalculated data became 543.7 seconds (roughly 9 minutes).
+
+The cached data is a lookup table where the coordinate sequences of respective street edges are used as keys for calculated data. Therefore, it is expected that over time various edits to OpenStreetMap will cause this cached data to become stale and not include new OSM ways. Therefore, periodic update of this cached data is recommended.
 
 ## Fares configuration
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -200,7 +200,7 @@ You can configure it as follows in `build-config.json`:
 
 ### Geoid Difference
 
-With some elevation data, the elevation values are specified as relative to the a geoid (irregular estimate of mean sea level). See [issue #2301](https://github.com/opentripplanner/OpenTripPlanner/issues/2301) for detailed discussion of this. In this cases, it is necessary to also add this geoid value onto the elevation value to get the correct result. OTP can automatically calculate these values in one of two ways. 
+With some elevation data, the elevation values are specified as relative to the a geoid (irregular estimate of mean sea level). See [issue #2301](https://github.com/opentripplanner/OpenTripPlanner/issues/2301) for detailed discussion of this. In these cases, it is necessary to also add this geoid value onto the elevation value to get the correct result. OTP can automatically calculate these values in one of two ways. 
 
 The first way is to use the geoid difference value that is calculated once at the center of the graph. This value is returned in each trip plan response in the [ElevationMetadata](http://otp-docs.ibi-transit.com/api/json_ElevationMetadata.html) field. Using a single value can be sufficient for smaller OTP deployments, but might result in incorrect values at the edges of larger OTP deployments. If your OTP instance uses this, it is recommended to set a default request value in the `router-config.json` file as follows:
 

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -299,7 +299,9 @@ public class GraphBuilder implements Runnable {
                     gcf,
                     params.cacheDirectory,
                     builderParams.readCachedElevations,
-                    builderParams.writeCachedElevations
+                    builderParams.writeCachedElevations,
+                    builderParams.includeEllipsoidToGeoidDifference,
+                    builderParams.geoidDifferenceSignficantDigits
                 )
             );
         }

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -300,8 +300,7 @@ public class GraphBuilder implements Runnable {
                     params.cacheDirectory,
                     builderParams.readCachedElevations,
                     builderParams.writeCachedElevations,
-                    builderParams.includeEllipsoidToGeoidDifference,
-                    builderParams.geoidDifferenceSignficantDigits
+                    builderParams.includeEllipsoidToGeoidDifference
                 )
             );
         }

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -280,7 +280,6 @@ public class GraphBuilder implements Runnable {
             S3BucketConfig bucketConfig = builderParams.elevationBucket;
             File cacheDirectory = new File(params.cacheDirectory, "ned");
             DegreeGridNEDTileSource awsTileSource = new DegreeGridNEDTileSource();
-            awsTileSource = new DegreeGridNEDTileSource();
             awsTileSource.awsAccessKey = bucketConfig.accessKey;
             awsTileSource.awsSecretKey = bucketConfig.secretKey;
             awsTileSource.awsBucketName = bucketConfig.bucketName;

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -180,7 +180,6 @@ public class GraphBuilder implements Runnable {
             LOG.error("'{}' is not a readable directory.", dir);
             return null;
         }
-        File cachedElevationsFile = Paths.get(dir.getAbsolutePath(), "cached_elevations.obj").toFile();
 
         // Find and parse config files first to reveal syntax errors early without waiting for graph build.
         builderConfig = OTPMain.loadJson(new File(dir, BUILDER_CONFIG_FILENAME));
@@ -209,9 +208,6 @@ public class GraphBuilder implements Runnable {
                     } else {
                         LOG.info("Skipping DEM file {}", file);
                     }
-                    break;
-                case CACHED_ELEVATIONS:
-                    LOG.info("Found cached elevations file {}", file);
                     break;
                 case OTHER:
                     LOG.warn("Skipping unrecognized file '{}'", file);
@@ -278,7 +274,7 @@ public class GraphBuilder implements Runnable {
         graphBuilder.addModule(streetLinkerModule);
         // Load elevation data and apply it to the streets.
         // We want to do run this module after loading the OSM street network but before finding transfers.
-        ElevationModule elevationBuilder = null;
+        ElevationGridCoverageFactory gcf = null;
         if (builderParams.elevationBucket != null) {
             // Download the elevation tiles from an Amazon S3 bucket
             S3BucketConfig bucketConfig = builderParams.elevationBucket;
@@ -288,24 +284,24 @@ public class GraphBuilder implements Runnable {
             awsTileSource.awsAccessKey = bucketConfig.accessKey;
             awsTileSource.awsSecretKey = bucketConfig.secretKey;
             awsTileSource.awsBucketName = bucketConfig.bucketName;
-            NEDGridCoverageFactoryImpl gcf = new NEDGridCoverageFactoryImpl(cacheDirectory);
-            gcf.tileSource = awsTileSource;
-            elevationBuilder = new ElevationModule(gcf);
+            gcf = new NEDGridCoverageFactoryImpl(cacheDirectory, awsTileSource);
         } else if (builderParams.fetchElevationUS) {
             // Download the elevation tiles from the official web service
             File cacheDirectory = new File(params.cacheDirectory, "ned");
-            ElevationGridCoverageFactory gcf = new NEDGridCoverageFactoryImpl(cacheDirectory);
-            elevationBuilder = new ElevationModule(gcf);
+            gcf = new NEDGridCoverageFactoryImpl(cacheDirectory);
         } else if (demFile != null) {
             // Load the elevation from a file in the graph inputs directory
-            ElevationGridCoverageFactory gcf = new GeotiffGridCoverageFactoryImpl(demFile);
-            elevationBuilder = new ElevationModule(gcf);
+            gcf = new GeotiffGridCoverageFactoryImpl(demFile);
         }
-        if (elevationBuilder != null) {
-            // add in extra settings that can lookup elevation data from previous graph builds
-            elevationBuilder.setCacheElevations(builderParams.cacheElevations);
-            elevationBuilder.setCachedElevationsFile(cachedElevationsFile);
-            graphBuilder.addModule(elevationBuilder);
+        if (gcf != null) {
+            graphBuilder.addModule(
+                new ElevationModule(
+                    gcf,
+                    params.cacheDirectory,
+                    builderParams.readCachedElevations,
+                    builderParams.writeCachedElevations
+                )
+            );
         }
         if ( hasGTFS ) {
             // The stops can be linked to each other once they are already linked to the street network.
@@ -328,7 +324,7 @@ public class GraphBuilder implements Runnable {
      * types are present. This helps point out when config files have been misnamed (builder-config vs. build-config).
      */
     private static enum InputFileType {
-        GTFS, OSM, DEM, CACHED_ELEVATIONS, CONFIG, GRAPH, OTHER;
+        GTFS, OSM, DEM, CONFIG, GRAPH, OTHER;
         public static InputFileType forFile(File file) {
             String name = file.getName();
             if (name.endsWith(".zip")) {
@@ -344,7 +340,6 @@ public class GraphBuilder implements Runnable {
             if (name.endsWith(".osm.xml")) return OSM;
             if (name.endsWith(".tif") || name.endsWith(".tiff")) return DEM; // Digital elevation model (elevation raster)
             if (name.equals("Graph.obj")) return GRAPH;
-            if (name.equals("cached_elevations.obj")) return CACHED_ELEVATIONS;
             if (name.equals(GraphBuilder.BUILDER_CONFIG_FILENAME) || name.equals(Router.ROUTER_CONFIG_FILENAME)) {
                 return CONFIG;
             }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/DegreeGridNEDTileSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/DegreeGridNEDTileSource.java
@@ -106,10 +106,9 @@ public class DegreeGridNEDTileSource implements NEDTileSource {
             log.info("Downloading NED degree tile " + path);
             // download the file from S3.
             AWSCredentials awsCredentials = new AWSCredentials(awsAccessKey, awsSecretKey);
-            String key = null;
+            String key = formatLatLon(x, y) + ".tiff";
             try {
                 S3Service s3Service = new RestS3Service(awsCredentials);
-                key = formatLatLon(x, y) + ".tiff";
                 S3Object object = s3Service.getObject(awsBucketName, key);
 
                 InputStream istream = object.getDataInputStream();

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/DegreeGridNEDTileSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/DegreeGridNEDTileSource.java
@@ -43,19 +43,18 @@ public class DegreeGridNEDTileSource implements NEDTileSource {
 
     public String awsBucketName;
 
-    @Override
-    public void setGraph(Graph graph) {
+    @Override public void fetchData(Graph graph, File cacheDirectory) {
         this.graph = graph;
-    }
-
-    @Override
-    public void setCacheDirectory(File cacheDirectory) {
         this.cacheDirectory = cacheDirectory;
+        getNEDTiles(true);
     }
 
     @Override
     public List<File> getNEDTiles() {
+        return getNEDTiles(false);
+    }
 
+    public List<File> getNEDTiles(boolean downloadIfMissing) {
         HashSet<P2<Integer>> tiles = new HashSet<P2<Integer>>();
 
         for (Vertex v : graph.getVertices()) {
@@ -67,7 +66,7 @@ public class DegreeGridNEDTileSource implements NEDTileSource {
         for (P2<Integer> tile : tiles) {
             int x = tile.first - 1;
             int y = tile.second + 1;
-            File tilePath = getPathToTile(x, y);
+            File tilePath = getPathToTile(x, y, downloadIfMissing);
             if (tilePath != null) {
                 paths.add(tilePath);
             }
@@ -92,10 +91,12 @@ public class DegreeGridNEDTileSource implements NEDTileSource {
         return String.format("%s%d%s%03d", northSouth, y, eastWest, x);
     }
 
-    private File getPathToTile(int x, int y) {
+    private File getPathToTile(int x, int y, boolean downloadIfMissing) {
         File path = new File(cacheDirectory, formatLatLon(x, y) + ".tiff");
         if (path.exists()) {
             return path;
+        } else if (!downloadIfMissing) {
+            return null;
         } else {
             path.getParentFile().mkdirs();
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -71,9 +71,10 @@ public class ElevationModule implements GraphBuilderModule {
 
     private Coverage coverage;
 
-    // Keep track of the proportion of elevation fetch operations that fail so we can issue warnings.
-    private AtomicInteger nPointsEvaluated = new AtomicInteger(0);
-    private AtomicInteger nPointsOutsideDEM = new AtomicInteger(0);
+    // Keep track of the proportion of elevation fetch operations that fail so we can issue warnings. AtomicInteger is
+    // used to provide thread-safe updating capabilities.
+    private final AtomicInteger nPointsEvaluated = new AtomicInteger(0);
+    private final AtomicInteger nPointsOutsideDEM = new AtomicInteger(0);
 
     /**
      * The distance between samples in meters. Defaults to 10m, the approximate resolution of 1/3

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -139,19 +139,15 @@ public class ElevationModule implements GraphBuilderModule {
         }
 
         // try to load in the cached elevation data
-        try {
-            ObjectInputStream in = new ObjectInputStream(new FileInputStream(cachedElevationsFile));
-            cachedElevations = (HashMap<String, PackedCoordinateSequence>) in.readObject();
-            log.info("Cached elevation data loaded into memory!");
-        } catch (IOException | ClassNotFoundException e) {
-            log.warn(graph.addBuilderAnnotation(
-                new Graphwide(
-                    String.format(
-                        "Cached elevations file could not be read in due to error: %s!",
-                        e.getMessage()
-                    )
-                )
-            ));
+        if (cacheElevations) {
+            try {
+                ObjectInputStream in = new ObjectInputStream(new FileInputStream(cachedElevationsFile));
+                cachedElevations = (HashMap<String, PackedCoordinateSequence>) in.readObject();
+                log.info("Cached elevation data loaded into memory!");
+            } catch (IOException | ClassNotFoundException e) {
+                log.warn(graph.addBuilderAnnotation(new Graphwide(
+                    String.format("Cached elevations file could not be read in due to error: %s!", e.getMessage()))));
+            }
         }
         log.info(demPrepareTask.finish());
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -617,9 +617,9 @@ public class ElevationModule implements GraphBuilderModule {
 
     /**
      * The Calculation of the EllipsoidToGeoidDifference is a very expensive operation, so the resulting values are
-     * cached based on the coordinate values up to 2 significant digits. Two signficant digits is often more than enough
+     * cached based on the coordinate values up to 2 significant digits. Two significant digits are often more than enough
      * for most parts of the world, but is useful for certain areas that have dramatic changes. Since the values are
-     * computer once and cached, it has almost no affect on performance to have this level of detail.
+     * computed once and cached, it has almost no affect on performance to have this level of detail.
      * See this image for an approximate mapping of these difference values:
      * https://earth-info.nga.mil/GandG/images/ww15mgh2.gif
      *

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -39,23 +39,23 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.file.Files;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * {@link org.opentripplanner.graph_builder.services.GraphBuilderModule} plugin that applies elevation data to street data that has already
- * been loaded into a (@link Graph}, creating elevation profiles for each Street encountered
- * in the Graph. Depending on the {@link ElevationGridCoverageFactory} specified
- * this could be auto-downloaded and cached National Elevation Dataset (NED) raster data or
- * a GeoTIFF file. The elevation profiles are stored as {@link PackedCoordinateSequence} objects,
- * where each (x,y) pair represents one sample, with the x-coord representing the distance along
- * the edge measured from the start, and the y-coord representing the sampled elevation at that
+ * {@link org.opentripplanner.graph_builder.services.GraphBuilderModule} plugin that applies elevation data to street
+ * data that has already been loaded into a (@link Graph}, creating elevation profiles for each Street encountered
+ * in the Graph. Depending on the {@link ElevationGridCoverageFactory} specified this could be auto-downloaded and
+ * cached National Elevation Dataset (NED) raster data or a GeoTIFF file. The elevation profiles are stored as
+ * {@link PackedCoordinateSequence} objects, where each (x,y) pair represents one sample, with the x-coord representing
+ * the distance along the edge measured from the start, and the y-coord representing the sampled elevation at that
  * point (both in meters).
  */
 public class ElevationModule implements GraphBuilderModule {
@@ -67,14 +67,24 @@ public class ElevationModule implements GraphBuilderModule {
     private final boolean writeCachedElevations;
     private final File cachedElevationsFile;
 
-    private HashMap<String, PackedCoordinateSequence> cachedElevations;
+    /**
+     * In regular use of OTP, no transformation is needed, however, in order to make an assertion in a downstream
+     * library pass during testing, a transformation must take place.
+     */
+    private final boolean transformCoordinates;
 
-    private Coverage coverage;
+    private HashMap<String, PackedCoordinateSequence> cachedElevations;
 
     // Keep track of the proportion of elevation fetch operations that fail so we can issue warnings. AtomicInteger is
     // used to provide thread-safe updating capabilities.
+    private AtomicInteger nEdgesProcessed = new AtomicInteger(0);
     private final AtomicInteger nPointsEvaluated = new AtomicInteger(0);
     private final AtomicInteger nPointsOutsideDEM = new AtomicInteger(0);
+    /**
+     * This initial value probably won't be shown in logs, but is set to an absurdly high value initially to make things
+     * seem better later.
+     */
+    private int totalElevationEdges = Integer.MAX_VALUE;
 
     /**
      * The distance between samples in meters. Defaults to 10m, the approximate resolution of 1/3
@@ -85,12 +95,16 @@ public class ElevationModule implements GraphBuilderModule {
     /** used to transform street coordinates into the projection used by the elevation data */
     private MathTransform transformer;
 
+    /** the graph being built */
+    private Graph graph;
+
     // used only for testing purposes
     public ElevationModule(ElevationGridCoverageFactory factory) {
         gridCoverageFactory = factory;
         cachedElevationsFile = null;
         readCachedElevations = false;
         writeCachedElevations = false;
+        transformCoordinates = true;
     }
 
     public ElevationModule(
@@ -103,6 +117,7 @@ public class ElevationModule implements GraphBuilderModule {
         cachedElevationsFile = new File(cacheDirectory, "cached_elevations.obj");
         this.readCachedElevations = readCachedElevations;
         this.writeCachedElevations = writeCachedElevations;
+        transformCoordinates = false;
     }
 
     public List<String> provides() {
@@ -115,28 +130,21 @@ public class ElevationModule implements GraphBuilderModule {
 
     @Override
     public void buildGraph(Graph graph, GraphBuilderModuleSummary graphBuilderModuleSummary) {
+        this.graph = graph;
         GraphBuilderTaskSummary demPrepareTask = graphBuilderModuleSummary.addSubTask(
             "fetch and prepare elevation data"
         );
         log.info(demPrepareTask.start());
 
         gridCoverageFactory.setGraph(graph);
-        Coverage gridCov = gridCoverageFactory.getGridCoverage();
-
-        // If gridCov is a GridCoverage2D, apply a bilinear interpolator. Otherwise, just use the
-        // coverage as is (note: UnifiedGridCoverages created by NEDGridCoverageFactoryImpl handle
-        // interpolation internally)
-        coverage = (gridCov instanceof GridCoverage2D) ? Interpolator2D.create(
-                (GridCoverage2D) gridCov, new InterpolationBilinear()) : gridCov;
-        try {
-            transformer = CRS.findMathTransform(
-                GeometryUtils.WGS84_XY,
-                coverage.getCoordinateReferenceSystem(),
-                true
-            );
-        } catch (FactoryException e) {
-            log.error("Could not find an appropriate transformer!");
-            throw new RuntimeException(e);
+        if (transformCoordinates) {
+            try {
+                transformer = CRS
+                    .findMathTransform(GeometryUtils.WGS84_XY, getCoverage().getCoordinateReferenceSystem(), true);
+            } catch (FactoryException e) {
+                log.error("Could not find an appropriate transformer!");
+                throw new RuntimeException(e);
+            }
         }
 
         // try to load in the cached elevation data
@@ -157,32 +165,30 @@ public class ElevationModule implements GraphBuilderModule {
         );
         log.info(setElevationsFromDEMTask.start());
 
-        AtomicInteger nProcessed = new AtomicInteger();
+        // Multithread elevation calculations
+        ForkJoinPool forkJoinPool = new ForkJoinPool();
 
-        LinkedList<StreetWithElevationEdge> edgesToCalculate = new LinkedList<>();
+        // For unknown reasons, the interpolation of heights at coordinates is a synchronized method in the commonly
+        // used Interpolator2D class. Therefore, it is critical to use a dedicated Coverage instance for each thread to
+        // avoid other threads waiting for a lock to be released on the Coverage instance. This concurrent HashMap will
+        // store these thread-specific Coverage instances.
+        ConcurrentHashMap<Long, Coverage> coveragesForThread = new ConcurrentHashMap<>();
+
+        List<StreetWithElevationEdge> streetWithElevationEdges = new LinkedList<>();
         for (Vertex gv : graph.getVertices()) {
             for (Edge ee : gv.getOutgoing()) {
                 if (ee instanceof StreetWithElevationEdge) {
-                    edgesToCalculate.add((StreetWithElevationEdge) ee);
+                    forkJoinPool.submit(new ProcessEdgeTask((StreetWithElevationEdge) ee, coveragesForThread));
+                    streetWithElevationEdges.add((StreetWithElevationEdge) ee);
                 }
             }
         }
-
-        edgesToCalculate.parallelStream().forEach(edgeWithElevation -> {
-            processEdge(graph, edgeWithElevation);
-            int curNumProcessed = nProcessed.addAndGet(1);
-            if (curNumProcessed % 50000 == 0) {
-                log.info("set elevation on {}/{} edges", curNumProcessed, edgesToCalculate.size());
-            }
-        });
-
-        // iterate again to find edges that had elevation calculated. This is done here instead of in the above loop to
-        // avoid thread locking for writes to a synchronized list
-        LinkedList<StreetEdge> edgesWithElevation = new LinkedList<>();
-        for (StreetWithElevationEdge edgeWithElevation : edgesToCalculate) {
-            if (edgeWithElevation.hasPackedElevationProfile() && !edgeWithElevation.isElevationFlattened()) {
-                edgesWithElevation.add(edgeWithElevation);
-            }
+        totalElevationEdges = streetWithElevationEdges.size();
+        forkJoinPool.shutdown();
+        try {
+            forkJoinPool.awaitTermination(1, TimeUnit.DAYS);
+        } catch (InterruptedException e) {
+            log.warn(graph.addBuilderAnnotation(new Graphwide("Multi-threaded elevation calculations timed-out!")));
         }
 
         double failurePercentage = nPointsOutsideDEM.get() / nPointsEvaluated.get() * 100;
@@ -197,10 +203,19 @@ public class ElevationModule implements GraphBuilderModule {
                 "If it is unprojected, perhaps the axes are not in (longitude, latitude) order.");
         }
 
+        // iterate again to find edges that had elevation calculated. This is done here instead of in the forkJoinPool
+        // to avoid thread locking for writes to a synchronized list
+        LinkedList<StreetEdge> edgesWithCalculatedElevations = new LinkedList<>();
+        for (StreetWithElevationEdge edgeWithElevation : streetWithElevationEdges) {
+            if (edgeWithElevation.hasPackedElevationProfile() && !edgeWithElevation.isElevationFlattened()) {
+                edgesWithCalculatedElevations.add(edgeWithElevation);
+            }
+        }
+
         if (writeCachedElevations) {
             // write information from edgesWithElevation to a new cache file for subsequent graph builds
             HashMap<String, PackedCoordinateSequence> newCachedElevations = new HashMap<>();
-            for (StreetEdge streetEdge : edgesWithElevation) {
+            for (StreetEdge streetEdge : edgesWithCalculatedElevations) {
                 newCachedElevations.put(PolylineEncoder.createEncodings(streetEdge.getGeometry()).getPoints(),
                     streetEdge.getElevationProfile());
             }
@@ -220,8 +235,53 @@ public class ElevationModule implements GraphBuilderModule {
             "calculate missing elevations"
         );
         log.info(missingElevationsTask.start());
-        assignMissingElevations(graph, edgesWithElevation);
+        assignMissingElevations(graph, edgesWithCalculatedElevations);
         log.info(missingElevationsTask.finish());
+    }
+
+    /**
+     * A runnable that contains the relevant info for executing a process edge operation in a particular thread.
+     */
+    private class ProcessEdgeTask implements Runnable {
+        private final StreetWithElevationEdge swee;
+        private final ConcurrentHashMap<Long, Coverage> coveragesForThread;
+
+        public ProcessEdgeTask(StreetWithElevationEdge swee, ConcurrentHashMap<Long, Coverage> coveragesForThread) {
+            this.swee = swee;
+            this.coveragesForThread = coveragesForThread;
+        }
+
+        @Override public void run() {
+            processEdge(swee, getThreadSpecificCoverageInstance());
+        }
+
+        /**
+         * Get the thread-specific Coverage instance to avoid multiple threads waiting for a lock to be released on a
+         * Interpolator2D instance.
+         */
+        private Coverage getThreadSpecificCoverageInstance () {
+            long currentThreadId = Thread.currentThread().getId();
+            Coverage threadSpecificCoverage = coveragesForThread.get(currentThreadId);
+            if (threadSpecificCoverage == null) {
+                threadSpecificCoverage = getCoverage();
+                coveragesForThread.put(currentThreadId, threadSpecificCoverage);
+            }
+            return threadSpecificCoverage;
+        }
+    }
+
+    /**
+     * Get an uncached Coverage instance from the module's ElevationGridCoverageFactory.
+     */
+    private Coverage getCoverage() {
+        // If gridCov is a GridCoverage2D, apply a bilinear interpolator. Otherwise, just use the
+        // coverage as is (note: UnifiedGridCoverages created by NEDGridCoverageFactoryImpl handle
+        // interpolation internally)
+        Coverage gridCov = gridCoverageFactory instanceof NEDGridCoverageFactoryImpl
+            ? ((NEDGridCoverageFactoryImpl) gridCoverageFactory).getUncachedCoverage()
+            : gridCoverageFactory.getGridCoverage();
+        return (gridCov instanceof GridCoverage2D) ? Interpolator2D.create(
+            (GridCoverage2D) gridCov, new InterpolationBilinear()) : gridCov;
     }
 
     class ElevationRepairState {
@@ -425,11 +485,11 @@ public class ElevationModule implements GraphBuilderModule {
 
     /**
      * Processes a single street edge, creating and assigning the elevation profile.
-     * 
+     *
      * @param ee the street edge
-     * @param graph the graph (used only for error handling)
+     * @param coverage the specific Coverage instance to use in order to avoid competition between threads
      */
-    private void processEdge(Graph graph, StreetWithElevationEdge ee) {
+    private void processEdge(StreetWithElevationEdge ee, Coverage coverage) {
         if (ee.hasPackedElevationProfile()) {
             return; /* already set up */
         }
@@ -456,7 +516,7 @@ public class ElevationModule implements GraphBuilderModule {
             List<Coordinate> coordList = new LinkedList<Coordinate>();
 
             // initial sample (x = 0)
-            coordList.add(new Coordinate(0, getElevation(coords[0])));
+            coordList.add(new Coordinate(0, getElevation(coverage, coords[0])));
 
             // iterate through coordinates calculating the edge length and creating intermediate elevation coordinates at
             // the regularly specified interval
@@ -480,6 +540,7 @@ public class ElevationModule implements GraphBuilderModule {
                         new Coordinate(
                             sampleDistance,
                             getElevation(
+                                coverage,
                                 new Coordinate(
                                     x1 + (pctAlongSeg * (x2 - x1)),
                                     y1 + (pctAlongSeg * (y2 - y1))
@@ -500,7 +561,7 @@ public class ElevationModule implements GraphBuilderModule {
             }
 
             // final sample (x = edge length)
-            coordList.add(new Coordinate(edgeLenM, getElevation(coords[coords.length - 1])));
+            coordList.add(new Coordinate(edgeLenM, getElevation(coverage, coords[coords.length - 1])));
 
             // construct the PCS
             Coordinate coordArr[] = new Coordinate[coordList.size()];
@@ -510,6 +571,10 @@ public class ElevationModule implements GraphBuilderModule {
             setEdgeElevationProfile(ee, elevPCS, graph);
         } catch (PointOutsideCoverageException | TransformException e) {
             log.debug("Error processing elevation for edge: {} due to error: {}", ee, e);
+        }
+        int curNumProcessed = nEdgesProcessed.addAndGet(1);
+        if (curNumProcessed % 50000 == 0) {
+            log.info("set elevation on {}/{} edges", curNumProcessed, totalElevationEdges);
         }
     }
 
@@ -523,22 +588,24 @@ public class ElevationModule implements GraphBuilderModule {
 
     /**
      * Method for retrieving the elevation at a given Coordinate.
-     * 
+     *
+     * @param coverage the specific Coverage instance to use in order to avoid competition between threads
      * @param c the coordinate (NAD83)
      * @return elevation in meters
      */
-    private double getElevation(Coordinate c) throws PointOutsideCoverageException, TransformException {
-        return getElevation(c.x, c.y);
+    private double getElevation(Coverage coverage, Coordinate c) throws PointOutsideCoverageException, TransformException {
+        return getElevation(coverage, c.x, c.y);
     }
 
     /**
      * Method for retrieving the elevation at a given (x, y) pair.
-     * 
+     *
+     * @param coverage the specific Coverage instance to use in order to avoid competition between threads
      * @param x the query longitude (NAD83)
      * @param y the query latitude (NAD83)
      * @return elevation in meters
      */
-    private double getElevation(double x, double y) throws PointOutsideCoverageException, TransformException {
+    private double getElevation(Coverage coverage, double x, double y) throws PointOutsideCoverageException, TransformException {
         double values[] = new double[1];
         try {
             // We specify a CRS here because otherwise the coordinates are assumed to be in the coverage's native CRS.
@@ -547,9 +614,16 @@ public class ElevationModule implements GraphBuilderModule {
             // for DefaultGeographicCRS.WGS84, but OTP is using (long, lat) throughout and assumes unprojected DEM
             // rasters to also use (long, lat).
             DirectPosition2D projectedPosition = new DirectPosition2D(GeometryUtils.WGS84_XY, x, y);
-            DirectPosition2D transformedPosition = new DirectPosition2D();
-            transformer.transform(projectedPosition, transformedPosition);
-            coverage.evaluate(transformedPosition, values);
+            DirectPosition2D position2D;
+            // If this is not done during testing, a downstream library will raise an assertion error
+            if (transformCoordinates) {
+                DirectPosition2D transformedPosition = new DirectPosition2D();
+                transformer.transform(projectedPosition, transformedPosition);
+                position2D = transformedPosition;
+            } else {
+                position2D = projectedPosition;
+            }
+            coverage.evaluate(position2D, values);
         } catch (PointOutsideCoverageException | TransformException e) {
             nPointsOutsideDEM.incrementAndGet();
             throw e;

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -62,11 +62,10 @@ public class ElevationModule implements GraphBuilderModule {
 
     private static final Logger log = LoggerFactory.getLogger(ElevationModule.class);
 
-    private ElevationGridCoverageFactory gridCoverageFactory;
-
-    private boolean cacheElevations = false;
-
-    private File cachedElevationsFile;
+    private final ElevationGridCoverageFactory gridCoverageFactory;
+    private final boolean readCachedElevations;
+    private final boolean writeCachedElevations;
+    private final File cachedElevationsFile;
 
     private HashMap<String, PackedCoordinateSequence> cachedElevations;
 
@@ -85,10 +84,24 @@ public class ElevationModule implements GraphBuilderModule {
     /** used to transform street coordinates into the projection used by the elevation data */
     private MathTransform transformer;
 
-    public ElevationModule() { /* This makes me a "bean" */ };
-    
+    // used only for testing purposes
     public ElevationModule(ElevationGridCoverageFactory factory) {
-        this.setGridCoverageFactory(factory);
+        gridCoverageFactory = factory;
+        cachedElevationsFile = null;
+        readCachedElevations = false;
+        writeCachedElevations = false;
+    }
+
+    public ElevationModule(
+        ElevationGridCoverageFactory factory,
+        File cacheDirectory,
+        boolean readCachedElevations,
+        boolean writeCachedElevations
+    ) {
+        gridCoverageFactory = factory;
+        cachedElevationsFile = new File(cacheDirectory, "cached_elevations.obj");
+        this.readCachedElevations = readCachedElevations;
+        this.writeCachedElevations = writeCachedElevations;
     }
 
     public List<String> provides() {
@@ -97,20 +110,6 @@ public class ElevationModule implements GraphBuilderModule {
 
     public List<String> getPrerequisites() {
         return Arrays.asList("streets");
-    }
-    
-    public void setGridCoverageFactory(ElevationGridCoverageFactory factory) {
-        gridCoverageFactory = factory;
-    }
-
-    public void setDistanceBetweenSamplesM(double distance) {
-        distanceBetweenSamplesM = distance;
-    }
-
-    public void setCacheElevations(boolean cacheElevations) { this.cacheElevations = cacheElevations; }
-
-    public void setCachedElevationsFile(File cachedElevationsFile) {
-        this.cachedElevationsFile = cachedElevationsFile;
     }
 
     @Override
@@ -140,7 +139,7 @@ public class ElevationModule implements GraphBuilderModule {
         }
 
         // try to load in the cached elevation data
-        if (cacheElevations) {
+        if (readCachedElevations) {
             try {
                 ObjectInputStream in = new ObjectInputStream(new FileInputStream(cachedElevationsFile));
                 cachedElevations = (HashMap<String, PackedCoordinateSequence>) in.readObject();
@@ -192,7 +191,7 @@ public class ElevationModule implements GraphBuilderModule {
                 "If it is unprojected, perhaps the axes are not in (longitude, latitude) order.");
         }
 
-        if (cacheElevations) {
+        if (writeCachedElevations) {
             // write information from edgesWithElevation to a new cache file for subsequent graph builds
             HashMap<String, PackedCoordinateSequence> newCachedElevations = new HashMap<>();
             for (StreetEdge streetEdge : edgesWithElevation) {
@@ -558,7 +557,7 @@ public class ElevationModule implements GraphBuilderModule {
         gridCoverageFactory.checkInputs();
 
         // check for the existence of cached elevation data.
-        if (cacheElevations) {
+        if (readCachedElevations) {
             if (Files.exists(cachedElevationsFile.toPath())) {
                 log.info("Cached elevations file found!");
             } else {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -7,6 +7,7 @@ import org.geotools.coverage.grid.Interpolator2D;
 import org.geotools.geometry.DirectPosition2D;
 import org.geotools.referencing.CRS;
 import org.opengis.coverage.Coverage;
+import org.opengis.coverage.PointOutsideCoverageException;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.TransformException;
@@ -442,64 +443,69 @@ public class ElevationModule implements GraphBuilderModule {
         }
 
         // did not find a cached value, calculate
+        // If any of the coordinates throw an error when trying to lookup their value, immediately bail and do not
+        // process the elevation on the edge
+        try {
+            Coordinate[] coords = g.getCoordinates();
 
-        Coordinate[] coords = g.getCoordinates();
+            List<Coordinate> coordList = new LinkedList<Coordinate>();
 
-        List<Coordinate> coordList = new LinkedList<Coordinate>();
+            // initial sample (x = 0)
+            coordList.add(new Coordinate(0, getElevation(coords[0])));
 
-        // initial sample (x = 0)
-        coordList.add(new Coordinate(0, getElevation(coords[0])));
+            // iterate through coordinates calculating the edge length and creating intermediate elevation coordinates at
+            // the regularly specified interval
+            double edgeLenM = 0;
+            double sampleDistance = distanceBetweenSamplesM;
+            double previousDistance = 0;
+            double x1 = coords[0].x, y1 = coords[0].y, x2, y2;
+            for (int i = 0; i < coords.length - 1; i++) {
+                x2 = coords[i + 1].x;
+                y2 = coords[i + 1].y;
+                double curSegmentDistance = SphericalDistanceLibrary.distance(y1, x1, y2, x2);
+                edgeLenM += curSegmentDistance;
+                while (edgeLenM > sampleDistance) {
+                    // if current edge length is longer than the current sample distance, insert new elevation coordinates
+                    // as needed until sample distance has caught up
 
-        // iterate through coordinates calculating the edge length and creating intermediate elevation coordinates at
-        // the regularly specified interval
-        double edgeLenM = 0;
-        double sampleDistance = distanceBetweenSamplesM;
-        double previousDistance = 0;
-        double x1 = coords[0].x, y1 = coords[0].y, x2, y2;
-        for (int i = 0; i < coords.length - 1; i++) {
-            x2 = coords[i + 1].x;
-            y2 = coords[i + 1].y;
-            double curSegmentDistance = SphericalDistanceLibrary.distance(y1, x1, y2, x2);
-            edgeLenM += curSegmentDistance;
-            while (edgeLenM > sampleDistance) {
-                // if current edge length is longer than the current sample distance, insert new elevation coordinates
-                // as needed until sample distance has caught up
-
-                // calculate percent of current segment that distance is between
-                double pctAlongSeg = (sampleDistance - previousDistance) / curSegmentDistance;
-                // add an elevation coordinate
-                coordList.add(
-                    new Coordinate(
-                        sampleDistance,
-                        getElevation(
-                            new Coordinate(
-                                x1 + (pctAlongSeg * (x2 - x1)),
-                                y1 + (pctAlongSeg * (y2 - y1))
+                    // calculate percent of current segment that distance is between
+                    double pctAlongSeg = (sampleDistance - previousDistance) / curSegmentDistance;
+                    // add an elevation coordinate
+                    coordList.add(
+                        new Coordinate(
+                            sampleDistance,
+                            getElevation(
+                                new Coordinate(
+                                    x1 + (pctAlongSeg * (x2 - x1)),
+                                    y1 + (pctAlongSeg * (y2 - y1))
+                                )
                             )
                         )
-                    )
-                );
-                sampleDistance += distanceBetweenSamplesM;
+                    );
+                    sampleDistance += distanceBetweenSamplesM;
+                }
+                previousDistance = edgeLenM;
+                x1 = x2;
+                y1 = y2;
             }
-            previousDistance = edgeLenM;
-            x1 = x2;
-            y1 = y2;
+
+            // remove final-segment sample if it is less than half the distance between samples
+            if (edgeLenM - coordList.get(coordList.size() - 1).x < distanceBetweenSamplesM / 2) {
+                coordList.remove(coordList.size() - 1);
+            }
+
+            // final sample (x = edge length)
+            coordList.add(new Coordinate(edgeLenM, getElevation(coords[coords.length - 1])));
+
+            // construct the PCS
+            Coordinate coordArr[] = new Coordinate[coordList.size()];
+            PackedCoordinateSequence elevPCS = new PackedCoordinateSequence.Double(
+                    coordList.toArray(coordArr));
+
+            setEdgeElevationProfile(ee, elevPCS, graph);
+        } catch (PointOutsideCoverageException | TransformException e) {
+            log.debug("Error processing elevation for edge: {} due to error: {}", ee, e);
         }
-
-        // remove final-segment sample if it is less than half the distance between samples
-        if (edgeLenM - coordList.get(coordList.size() - 1).x < distanceBetweenSamplesM / 2) {
-            coordList.remove(coordList.size() - 1);
-        }
-
-        // final sample (x = edge length)
-        coordList.add(new Coordinate(edgeLenM, getElevation(coords[coords.length - 1])));
-
-        // construct the PCS
-        Coordinate coordArr[] = new Coordinate[coordList.size()];
-        PackedCoordinateSequence elevPCS = new PackedCoordinateSequence.Double(
-                coordList.toArray(coordArr));
-
-        setEdgeElevationProfile(ee, elevPCS, graph);
     }
 
     private void setEdgeElevationProfile(StreetWithElevationEdge ee, PackedCoordinateSequence elevPCS, Graph graph) {
@@ -516,7 +522,7 @@ public class ElevationModule implements GraphBuilderModule {
      * @param c the coordinate (NAD83)
      * @return elevation in meters
      */
-    private double getElevation(Coordinate c) {
+    private double getElevation(Coordinate c) throws PointOutsideCoverageException, TransformException {
         return getElevation(c.x, c.y);
     }
 
@@ -527,7 +533,7 @@ public class ElevationModule implements GraphBuilderModule {
      * @param y the query latitude (NAD83)
      * @return elevation in meters
      */
-    private double getElevation(double x, double y) {
+    private double getElevation(double x, double y) throws PointOutsideCoverageException, TransformException {
         double values[] = new double[1];
         try {
             // We specify a CRS here because otherwise the coordinates are assumed to be in the coverage's native CRS.
@@ -539,8 +545,9 @@ public class ElevationModule implements GraphBuilderModule {
             DirectPosition2D transformedPosition = new DirectPosition2D();
             transformer.transform(projectedPosition, transformedPosition);
             coverage.evaluate(transformedPosition, values);
-        } catch (org.opengis.coverage.PointOutsideCoverageException | TransformException e) {
+        } catch (PointOutsideCoverageException | TransformException e) {
             nPointsOutsideDEM.incrementAndGet();
+            throw e;
         }
         nPointsEvaluated.incrementAndGet();
         return values[0];

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -365,25 +365,48 @@ public class ElevationModule implements GraphBuilderModule {
 
         List<Coordinate> coordList = new LinkedList<Coordinate>();
 
-        // calculate the total edge length in meters
-        double edgeLenM = 0;
-        for (int i = 0; i < coords.length - 1; i++) {
-            edgeLenM += SphericalDistanceLibrary.distance(coords[i].y, coords[i].x, coords[i + 1].y,
-                    coords[i + 1].x);
-        }
-
         // initial sample (x = 0)
         coordList.add(new Coordinate(0, getElevation(coords[0])));
 
-        // loop for edge-internal samples
-        for (double x = distanceBetweenSamplesM; x < edgeLenM; x += distanceBetweenSamplesM) {
-            // avoid final-segment samples less than half the distance between samples:
-            if (edgeLenM - x < distanceBetweenSamplesM / 2) {
-                break;
-            }
+        // iterate through coordinates calculating the edge length and creating intermediate elevation coordinates at
+        // the regularly specified interval
+        double edgeLenM = 0;
+        double sampleDistance = distanceBetweenSamplesM;
+        double previousDistance = 0;
+        double x1 = coords[0].x, y1 = coords[0].y, x2, y2;
+        for (int i = 0; i < coords.length - 1; i++) {
+            x2 = coords[i + 1].x;
+            y2 = coords[i + 1].y;
+            double curSegmentDistance = SphericalDistanceLibrary.distance(y1, x1, y2, x2);
+            edgeLenM += curSegmentDistance;
+            while (edgeLenM > sampleDistance) {
+                // if current edge length is longer than the current sample distance, insert new elevation coordinates
+                // as needed until sample distance has caught up
 
-            Coordinate internal = getPointAlongEdge(coords, edgeLenM, x / edgeLenM);
-            coordList.add(new Coordinate(x, getElevation(internal)));
+                // calculate percent of current segment that distance is between
+                double pctAlongSeg = (sampleDistance - previousDistance) / curSegmentDistance;
+                // add an elevation coordinate
+                coordList.add(
+                    new Coordinate(
+                        sampleDistance,
+                        getElevation(
+                            new Coordinate(
+                                x1 + (pctAlongSeg * (x2 - x1)),
+                                y1 + (pctAlongSeg * (y2 - y1))
+                            )
+                        )
+                    )
+                );
+                sampleDistance += distanceBetweenSamplesM;
+            }
+            previousDistance = edgeLenM;
+            x1 = x2;
+            y1 = y2;
+        }
+
+        // remove final-segment sample if it is less than half the distance between samples
+        if (edgeLenM - coordList.get(coordList.size() - 1).x < distanceBetweenSamplesM / 2) {
+            coordList.remove(coordList.size() - 1);
         }
 
         // final sample (x = edge length)
@@ -399,51 +422,6 @@ public class ElevationModule implements GraphBuilderModule {
                 log.trace(graph.addBuilderAnnotation(new ElevationFlattened(ee)));
             }
         }
-    }
-
-    /**
-     * Returns a coordinate along a path located at a specific point indicated by the percentage of
-     * distance covered from start to end.
-     * 
-     * @param coords the list of (x,y) coordinates that form the path
-     * @param length the total length of the path
-     * @param t the percentage (ranges from 0 to 1)
-     * @return the (x,y) coordinate at t
-     */
-    public Coordinate getPointAlongEdge(Coordinate[] coords, double length, double t) {
-
-        double pctThrough = 0; // current percentage of the edge length traversed
-
-        // endpoints of current segment within edge:
-        double x1 = coords[0].x, y1 = coords[0].y, x2, y2;
-
-        for (int i = 1; i < coords.length - 1; i++) { // loop through inner points
-            Coordinate innerPt = coords[i];
-            x2 = innerPt.x;
-            y2 = innerPt.y;
-
-            // percentage of total edge length represented by current segment:
-            double pct = SphericalDistanceLibrary.distance(y1, x1, y2, x2) / length;
-
-            if (pctThrough + pct > t) { // if current segment contains 't,' we're done
-                double pctAlongSeg = (t - pctThrough) / pct;
-                return new Coordinate(x1 + (pctAlongSeg * (x2 - x1)), y1
-                        + (pctAlongSeg * (y2 - y1)));
-            }
-
-            pctThrough += pct;
-            x1 = x2;
-            y1 = y2;
-        }
-
-        // handle the final segment separately
-        x2 = coords[coords.length - 1].x;
-        y2 = coords[coords.length - 1].y;
-
-        double pct = SphericalDistanceLibrary.distance(y1, x1, y2, x2) / length;
-        double pctAlongSeg = (t - pctThrough) / pct;
-
-        return new Coordinate(x1 + (pctAlongSeg * (x2 - x1)), y1 + (pctAlongSeg * (y2 - y1)));
     }
 
     /**

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -49,6 +49,8 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.opentripplanner.util.ElevationUtils.computeEllipsoidToGeoidDifference;
+
 /**
  * {@link org.opentripplanner.graph_builder.services.GraphBuilderModule} plugin that applies elevation data to street
  * data that has already been loaded into a (@link Graph}, creating elevation profiles for each Street encountered
@@ -66,6 +68,8 @@ public class ElevationModule implements GraphBuilderModule {
     private final boolean readCachedElevations;
     private final boolean writeCachedElevations;
     private final File cachedElevationsFile;
+    private final boolean includeEllipsoidToGeoidDifference;
+    private final int geoidDifferenceCoordinateValueMultiplier;
 
     /**
      * In regular use of OTP, no transformation is needed, however, in order to make an assertion in a downstream
@@ -98,12 +102,16 @@ public class ElevationModule implements GraphBuilderModule {
     /** the graph being built */
     private Graph graph;
 
+    private final ConcurrentHashMap<Integer, Double> geoidDifferenceCache = new ConcurrentHashMap<>();
+
     // used only for testing purposes
     public ElevationModule(ElevationGridCoverageFactory factory) {
         gridCoverageFactory = factory;
         cachedElevationsFile = null;
         readCachedElevations = false;
         writeCachedElevations = false;
+        includeEllipsoidToGeoidDifference = true;
+        geoidDifferenceCoordinateValueMultiplier = 10;
         transformCoordinates = true;
     }
 
@@ -111,12 +119,16 @@ public class ElevationModule implements GraphBuilderModule {
         ElevationGridCoverageFactory factory,
         File cacheDirectory,
         boolean readCachedElevations,
-        boolean writeCachedElevations
+        boolean writeCachedElevations,
+        boolean includeEllipsoidToGeoidDifference,
+        int geoidDifferenceSignficantDigits
     ) {
         gridCoverageFactory = factory;
         cachedElevationsFile = new File(cacheDirectory, "cached_elevations.obj");
         this.readCachedElevations = readCachedElevations;
         this.writeCachedElevations = writeCachedElevations;
+        this.includeEllipsoidToGeoidDifference = includeEllipsoidToGeoidDifference;
+        geoidDifferenceCoordinateValueMultiplier = (int) Math.pow(10, geoidDifferenceSignficantDigits);
         transformCoordinates = false;
     }
 
@@ -642,7 +654,32 @@ public class ElevationModule implements GraphBuilderModule {
             throw e;
         }
         nPointsEvaluated.incrementAndGet();
-        return values[0];
+        return values[0] - (includeEllipsoidToGeoidDifference ? getEllipsoidToGeoidDifference(y, x) : 0);
+    }
+
+    /**
+     * The Calculation of the EllipsoidToGeoidDifference is a very expensive operation, so the resulting values are
+     * cached based on the coordinate values and the desired amount of significant digits. The number of significant
+     * digits that should be considered will vary depending on what part of the world the graph is being built for.
+     * See this image for an approximate mapping of these difference values:
+     * https://earth-info.nga.mil/GandG/images/ww15mgh2.gif
+     *
+     * @param y latitue
+     * @param x longitue
+     */
+    private double getEllipsoidToGeoidDifference(double y, double x) throws TransformException {
+        int xVal = (int) Math.round(x * geoidDifferenceCoordinateValueMultiplier);
+        int yVal = (int) Math.round(y * geoidDifferenceCoordinateValueMultiplier);
+        int hash = yVal * 104729 + xVal;
+        Double difference = geoidDifferenceCache.get(hash);
+        if (difference == null) {
+            difference = computeEllipsoidToGeoidDifference(
+                yVal / (1.0 * geoidDifferenceCoordinateValueMultiplier),
+                xVal / (1.0 * geoidDifferenceCoordinateValueMultiplier)
+            );
+            geoidDifferenceCache.put(hash, difference);
+        }
+        return difference;
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -263,7 +263,20 @@ public class ElevationModule implements GraphBuilderModule {
             long currentThreadId = Thread.currentThread().getId();
             Coverage threadSpecificCoverage = coveragesForThread.get(currentThreadId);
             if (threadSpecificCoverage == null) {
-                threadSpecificCoverage = getCoverage();
+                // Synchronize the creation of the Thread-specific Coverage instances to avoid potential deadlocks that
+                // could arise from downstream classes that have synchronized methods.
+                synchronized (coveragesForThread) {
+                    threadSpecificCoverage = getCoverage();
+                    // The Coverage instance relies on some synchronized static methods shared across all threads that
+                    // can cause deadlocks if not fully initialized. Therefore, make a single request for the first
+                    // point on the edge to initialize these other items.
+                    Coordinate firstEdgeCoord =  swee.getGeometry().getCoordinates()[0];
+                    double[] dummy = new double[1];
+                    threadSpecificCoverage.evaluate(
+                        new DirectPosition2D(GeometryUtils.WGS84_XY, firstEdgeCoord.x, firstEdgeCoord.y),
+                        dummy
+                    );
+                }
                 coveragesForThread.put(currentThreadId, threadSpecificCoverage);
             }
             return threadSpecificCoverage;

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -157,10 +157,9 @@ public class ElevationModule implements GraphBuilderModule {
         );
         log.info(setElevationsFromDEMTask.start());
 
-        List<StreetEdge> edgesWithElevation = Collections.synchronizedList(new ArrayList<>());
         AtomicInteger nProcessed = new AtomicInteger();
 
-        List<StreetWithElevationEdge> edgesToCalculate = new ArrayList<>();
+        LinkedList<StreetWithElevationEdge> edgesToCalculate = new LinkedList<>();
         for (Vertex gv : graph.getVertices()) {
             for (Edge ee : gv.getOutgoing()) {
                 if (ee instanceof StreetWithElevationEdge) {
@@ -171,14 +170,20 @@ public class ElevationModule implements GraphBuilderModule {
 
         edgesToCalculate.parallelStream().forEach(edgeWithElevation -> {
             processEdge(graph, edgeWithElevation);
-            if (edgeWithElevation.hasPackedElevationProfile() && !edgeWithElevation.isElevationFlattened()) {
-                edgesWithElevation.add(edgeWithElevation);
-            }
             int curNumProcessed = nProcessed.addAndGet(1);
             if (curNumProcessed % 50000 == 0) {
                 log.info("set elevation on {}/{} edges", curNumProcessed, edgesToCalculate.size());
             }
         });
+
+        // iterate again to find edges that had elevation calculated. This is done here instead of in the above loop to
+        // avoid thread locking for writes to a synchronized list
+        LinkedList<StreetEdge> edgesWithElevation = new LinkedList<>();
+        for (StreetWithElevationEdge edgeWithElevation : edgesToCalculate) {
+            if (edgeWithElevation.hasPackedElevationProfile() && !edgeWithElevation.isElevationFlattened()) {
+                edgesWithElevation.add(edgeWithElevation);
+            }
+        }
 
         double failurePercentage = nPointsOutsideDEM.get() / nPointsEvaluated.get() * 100;
         if (failurePercentage > 50) {
@@ -247,7 +252,7 @@ public class ElevationModule implements GraphBuilderModule {
      */
     private void assignMissingElevations(
         Graph graph,
-        List<StreetEdge> edgesWithElevation
+        LinkedList<StreetEdge> edgesWithElevation
     ) {
 
         log.debug("Assigning missing elevations");

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -395,7 +395,9 @@ public class ElevationModule implements GraphBuilderModule {
                 coordList.toArray(coordArr));
 
         if(ee.setElevationProfile(elevPCS, false)) {
-            log.trace(graph.addBuilderAnnotation(new ElevationFlattened(ee)));
+            synchronized (graph) {
+                log.trace(graph.addBuilderAnnotation(new ElevationFlattened(ee)));
+            }
         }
     }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -2,8 +2,6 @@ package org.opentripplanner.graph_builder.module.ned;
 
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
-import org.geotools.coverage.grid.GridCoverage2D;
-import org.geotools.coverage.grid.Interpolator2D;
 import org.geotools.geometry.DirectPosition2D;
 import org.opengis.coverage.Coverage;
 import org.opengis.coverage.PointOutsideCoverageException;
@@ -27,7 +25,6 @@ import org.opentripplanner.util.PolylineEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.media.jai.InterpolationBilinear;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -51,11 +48,10 @@ import static org.opentripplanner.util.ElevationUtils.computeEllipsoidToGeoidDif
 /**
  * {@link org.opentripplanner.graph_builder.services.GraphBuilderModule} plugin that applies elevation data to street
  * data that has already been loaded into a (@link Graph}, creating elevation profiles for each Street encountered
- * in the Graph. Depending on the {@link ElevationGridCoverageFactory} specified this could be auto-downloaded and
- * cached National Elevation Dataset (NED) raster data or a GeoTIFF file. The elevation profiles are stored as
- * {@link PackedCoordinateSequence} objects, where each (x,y) pair represents one sample, with the x-coord representing
- * the distance along the edge measured from the start, and the y-coord representing the sampled elevation at that
- * point (both in meters).
+ * in the Graph. Data sources that could be used include auto-downloaded and cached National Elevation Dataset (NED)
+ * raster data or a GeoTIFF file. The elevation profiles are stored as {@link PackedCoordinateSequence} objects, where
+ * each (x,y) pair represents one sample, with the x-coord representing the distance along the edge measured from the
+ * start, and the y-coord representing the sampled elevation at that point (both in meters).
  */
 public class ElevationModule implements GraphBuilderModule {
 
@@ -133,7 +129,7 @@ public class ElevationModule implements GraphBuilderModule {
         );
         log.info(demPrepareTask.start());
 
-        gridCoverageFactory.setGraph(graph);
+        gridCoverageFactory.fetchData(graph);
 
         // try to load in the cached elevation data
         if (readCachedElevations) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -242,6 +242,10 @@ public class ElevationModule implements GraphBuilderModule {
 
         @Override public void run() {
             processEdge(swee, getThreadSpecificCoverageInstance());
+            int curNumProcessed = nEdgesProcessed.addAndGet(1);
+            if (curNumProcessed % 50000 == 0) {
+                log.info("set elevation on {}/{} edges", curNumProcessed, totalElevationEdges);
+            }
         }
 
         /**
@@ -560,10 +564,6 @@ public class ElevationModule implements GraphBuilderModule {
             setEdgeElevationProfile(ee, elevPCS, graph);
         } catch (PointOutsideCoverageException | TransformException e) {
             log.debug("Error processing elevation for edge: {} due to error: {}", ee, e);
-        }
-        int curNumProcessed = nEdgesProcessed.addAndGet(1);
-        if (curNumProcessed % 50000 == 0) {
-            log.info("set elevation on {}/{} edges", curNumProcessed, totalElevationEdges);
         }
     }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -5,7 +5,11 @@ import com.vividsolutions.jts.geom.Geometry;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.Interpolator2D;
 import org.geotools.geometry.DirectPosition2D;
+import org.geotools.referencing.CRS;
 import org.opengis.coverage.Coverage;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.operation.MathTransform;
+import org.opengis.referencing.operation.TransformException;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.common.geometry.PackedCoordinateSequence;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
@@ -463,8 +467,16 @@ public class ElevationModule implements GraphBuilderModule {
             // GeoTIFFs in various projections. Note that GeoTools defaults to strict EPSG axis ordering of (lat, long)
             // for DefaultGeographicCRS.WGS84, but OTP is using (long, lat) throughout and assumes unprojected DEM
             // rasters to also use (long, lat).
-            coverage.evaluate(new DirectPosition2D(GeometryUtils.WGS84_XY, x, y), values);
-        } catch (org.opengis.coverage.PointOutsideCoverageException e) {
+            DirectPosition2D projectedPosition = new DirectPosition2D(GeometryUtils.WGS84_XY, x, y);
+            MathTransform transformer = CRS.findMathTransform(
+                GeometryUtils.WGS84_XY,
+                coverage.getCoordinateReferenceSystem(),
+                true
+            );
+            DirectPosition2D transformedPosition = new DirectPosition2D();
+            transformer.transform(projectedPosition, transformedPosition);
+            coverage.evaluate(transformedPosition, values);
+        } catch (org.opengis.coverage.PointOutsideCoverageException | FactoryException | TransformException e) {
             nPointsOutsideDEM += 1;
         }
         nPointsEvaluated += 1;

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -66,6 +66,9 @@ public class ElevationModule implements GraphBuilderModule {
      */
     private double distanceBetweenSamplesM = 10;
 
+    /** used to transform street coordinates into the projection used by the elevation data */
+    private MathTransform transformer;
+
     public ElevationModule() { /* This makes me a "bean" */ };
     
     public ElevationModule(ElevationGridCoverageFactory factory) {
@@ -103,6 +106,16 @@ public class ElevationModule implements GraphBuilderModule {
         // interpolation internally)
         coverage = (gridCov instanceof GridCoverage2D) ? Interpolator2D.create(
                 (GridCoverage2D) gridCov, new InterpolationBilinear()) : gridCov;
+        try {
+            transformer = CRS.findMathTransform(
+                GeometryUtils.WGS84_XY,
+                coverage.getCoordinateReferenceSystem(),
+                true
+            );
+        } catch (FactoryException e) {
+            log.error("Could not find an appropriate transformer!");
+            throw new RuntimeException(e);
+        }
         log.info(demPrepareTask.finish());
 
         GraphBuilderTaskSummary setElevationsFromDEMTask = graphBuilderModuleSummary.addSubTask(
@@ -112,22 +125,25 @@ public class ElevationModule implements GraphBuilderModule {
 
         List<StreetEdge> edgesWithElevation = Collections.synchronizedList(new ArrayList<>());
         AtomicInteger nProcessed = new AtomicInteger();
-        int nTotal = graph.countEdges();
 
-        graph.getVertices().parallelStream().forEach(gv -> {
-            gv.getOutgoing().parallelStream().forEach(ee -> {
+        List<StreetWithElevationEdge> edgesToCalculate = new ArrayList<>();
+        for (Vertex gv : graph.getVertices()) {
+            for (Edge ee : gv.getOutgoing()) {
                 if (ee instanceof StreetWithElevationEdge) {
-                    StreetWithElevationEdge edgeWithElevation = (StreetWithElevationEdge) ee;
-                    processEdge(graph, edgeWithElevation);
-                    if (edgeWithElevation.getElevationProfile() != null && !edgeWithElevation.isElevationFlattened()) {
-                        edgesWithElevation.add(edgeWithElevation);
-                    }
-                    int curNumProcessed = nProcessed.addAndGet(1);
-                    if (curNumProcessed % 50000 == 0) {
-                        log.info("set elevation on {}/{} edges", curNumProcessed, nTotal);
-                    }
+                    edgesToCalculate.add((StreetWithElevationEdge) ee);
                 }
-            });
+            }
+        }
+
+        edgesToCalculate.parallelStream().forEach(edgeWithElevation -> {
+            processEdge(graph, edgeWithElevation);
+            if (edgeWithElevation.hasPackedElevationProfile() && !edgeWithElevation.isElevationFlattened()) {
+                edgesWithElevation.add(edgeWithElevation);
+            }
+            int curNumProcessed = nProcessed.addAndGet(1);
+            if (curNumProcessed % 50000 == 0) {
+                log.info("set elevation on {}/{} edges", curNumProcessed, edgesToCalculate.size());
+            }
         });
 
         double failurePercentage = nPointsOutsideDEM.get() / nPointsEvaluated.get() * 100;
@@ -357,7 +373,7 @@ public class ElevationModule implements GraphBuilderModule {
      * @param graph the graph (used only for error handling)
      */
     private void processEdge(Graph graph, StreetWithElevationEdge ee) {
-        if (ee.getElevationProfile() != null) {
+        if (ee.hasPackedElevationProfile()) {
             return; /* already set up */
         }
         Geometry g = ee.getGeometry();
@@ -450,15 +466,10 @@ public class ElevationModule implements GraphBuilderModule {
             // for DefaultGeographicCRS.WGS84, but OTP is using (long, lat) throughout and assumes unprojected DEM
             // rasters to also use (long, lat).
             DirectPosition2D projectedPosition = new DirectPosition2D(GeometryUtils.WGS84_XY, x, y);
-            MathTransform transformer = CRS.findMathTransform(
-                GeometryUtils.WGS84_XY,
-                coverage.getCoordinateReferenceSystem(),
-                true
-            );
             DirectPosition2D transformedPosition = new DirectPosition2D();
             transformer.transform(projectedPosition, transformedPosition);
             coverage.evaluate(transformedPosition, values);
-        } catch (org.opengis.coverage.PointOutsideCoverageException | FactoryException | TransformException e) {
+        } catch (org.opengis.coverage.PointOutsideCoverageException | TransformException e) {
             nPointsOutsideDEM.incrementAndGet();
         }
         nPointsEvaluated.incrementAndGet();

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/GeotiffGridCoverageFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/GeotiffGridCoverageFactoryImpl.java
@@ -37,7 +37,7 @@ public class GeotiffGridCoverageFactoryImpl implements ElevationGridCoverageFact
             GeoTiffFormat format = new GeoTiffFormat();
             GeoTiffReader reader = format.getReader(path, forceLongLat);
             coverage = reader.read(null);
-            LOG.info("Elevation model CRS is: {}", coverage.getCoordinateReferenceSystem2D());
+            LOG.debug("Elevation model CRS is: {}", coverage.getCoordinateReferenceSystem2D());
         } catch (IOException e) {
             throw new RuntimeException("Error getting coverage automatically. ", e);
         }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/GeotiffGridCoverageFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/GeotiffGridCoverageFactoryImpl.java
@@ -56,7 +56,7 @@ public class GeotiffGridCoverageFactoryImpl implements ElevationGridCoverageFact
     }
 
     @Override
-    public void setGraph(Graph graph) {
+    public void fetchData(Graph graph) {
         //nothing to do here
     }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/GeotiffGridCoverageFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/GeotiffGridCoverageFactoryImpl.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.graph_builder.module.ned;
 
 import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.Interpolator2D;
 import org.geotools.factory.Hints;
 import org.geotools.gce.geotiff.GeoTiffFormat;
 import org.geotools.gce.geotiff.GeoTiffReader;
@@ -9,6 +10,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.media.jai.InterpolationBilinear;
 import java.io.File;
 import java.io.IOException;
 
@@ -20,7 +22,6 @@ public class GeotiffGridCoverageFactoryImpl implements ElevationGridCoverageFact
     private static final Logger LOG = LoggerFactory.getLogger(GeotiffGridCoverageFactoryImpl.class);
 
     private final File path;
-    private GridCoverage2D coverage;
 
     public GeotiffGridCoverageFactoryImpl(File path) {
         this.path = path;
@@ -28,6 +29,7 @@ public class GeotiffGridCoverageFactoryImpl implements ElevationGridCoverageFact
 
     @Override
     public GridCoverage2D getGridCoverage() {
+        GridCoverage2D coverage;
         try {
             // There is a serious standardization failure around the axis order of WGS84. See issue #1930.
             // GeoTools assumes strict EPSG axis order of (latitude, longitude) unless told otherwise.
@@ -38,6 +40,8 @@ public class GeotiffGridCoverageFactoryImpl implements ElevationGridCoverageFact
             GeoTiffReader reader = format.getReader(path, forceLongLat);
             coverage = reader.read(null);
             LOG.debug("Elevation model CRS is: {}", coverage.getCoordinateReferenceSystem2D());
+            // TODO might bicubic interpolation give better results?
+            coverage = Interpolator2D.create(coverage, new InterpolationBilinear());
         } catch (IOException e) {
             throw new RuntimeException("Error getting coverage automatically. ", e);
         }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDDownloader.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDDownloader.java
@@ -45,6 +45,8 @@ public class NEDDownloader implements NEDTileSource {
 
     private double _lonXStep = 0.16;
 
+    private List<File> nedTiles;
+
     private File getPathToNEDArchive(String key) {
         if (!cacheDirectory.exists()) {
             if (!cacheDirectory.mkdirs()) {
@@ -282,20 +284,17 @@ public class NEDDownloader implements NEDTileSource {
         return lft + "_" + rgt + "_" + top + "_" + bot;
     }
 
+    @Override
+    public List<File> getNEDTiles() {
+        return nedTiles;
+    }
+
     @Override public void fetchData(Graph graph, File cacheDirectory) {
         this.graph = graph;
         this.cacheDirectory = cacheDirectory;
 
         log.info("Downloading NED elevation data (or fetching it from local cache).");
-        getNEDTiles(true);
-    }
-
-    @Override
-    public List<File> getNEDTiles() {
-        return getNEDTiles(false);
-    }
-
-    public List<File> getNEDTiles(boolean downloadIfMissing) {
+        
         List<URL> urls = getDownloadURLsCached();
         List<File> files = new ArrayList<File>();
         int tileCount = 0;
@@ -306,9 +305,6 @@ public class NEDDownloader implements NEDTileSource {
             if (tile.exists()) {
                 files.add(tile);
                 log.debug("{} found in NED cache, not downloading: {}", tileProgress, tile);
-                continue;
-            } else if (!downloadIfMissing) {
-                log.debug("{} not found in NED cache, but skipping download: {}", tileProgress, tile);
                 continue;
             }
             REQUEST: for (int req_attempt = 0; req_attempt < 5; ++req_attempt) {
@@ -340,7 +336,7 @@ public class NEDDownloader implements NEDTileSource {
             }
             log.error("Unable to download a NED tile after 5 requests.");
         }
-        return files;
+        nedTiles = files;
     }
 
     private List<URL> getDownloadURLsCached() {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDDownloader.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDDownloader.java
@@ -45,16 +45,6 @@ public class NEDDownloader implements NEDTileSource {
 
     private double _lonXStep = 0.16;
 
-    @Override
-    public void setGraph(Graph graph) {
-        this.graph = graph;
-    }
-
-    @Override
-    public void setCacheDirectory(File cacheDirectory) {
-        this.cacheDirectory = cacheDirectory;
-    }
-
     private File getPathToNEDArchive(String key) {
         if (!cacheDirectory.exists()) {
             if (!cacheDirectory.mkdirs()) {
@@ -292,9 +282,20 @@ public class NEDDownloader implements NEDTileSource {
         return lft + "_" + rgt + "_" + top + "_" + bot;
     }
 
+    @Override public void fetchData(Graph graph, File cacheDirectory) {
+        this.graph = graph;
+        this.cacheDirectory = cacheDirectory;
+
+        log.info("Downloading NED elevation data (or fetching it from local cache).");
+        getNEDTiles(true);
+    }
+
     @Override
     public List<File> getNEDTiles() {
-        log.info("Downloading NED elevation data (or fetching it from local cache).");
+        return getNEDTiles(false);
+    }
+
+    public List<File> getNEDTiles(boolean downloadIfMissing) {
         List<URL> urls = getDownloadURLsCached();
         List<File> files = new ArrayList<File>();
         int tileCount = 0;
@@ -305,6 +306,9 @@ public class NEDDownloader implements NEDTileSource {
             if (tile.exists()) {
                 files.add(tile);
                 log.debug("{} found in NED cache, not downloading: {}", tileProgress, tile);
+                continue;
+            } else if (!downloadIfMissing) {
+                log.debug("{} not found in NED cache, but skipping download: {}", tileProgress, tile);
                 continue;
             }
             REQUEST: for (int req_attempt = 0; req_attempt < 5; ++req_attempt) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDGridCoverageFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDGridCoverageFactoryImpl.java
@@ -107,16 +107,8 @@ public class NEDGridCoverageFactoryImpl implements ElevationGridCoverageFactory 
         }
     }
 
-    /** @return a GeoTools grid coverage for the entire area of interest, lazy-creating it on the first call. */
+    /** @return a GeoTools grid coverage for the entire area of interest. */
     public Coverage getGridCoverage() {
-        if (unifiedCoverage == null) {
-            unifiedCoverage = getUncachedCoverage();
-        }
-        return unifiedCoverage;
-    }
-
-    /** @return a GeoTools grid coverage for the entire area of interest */
-    public UnifiedGridCoverage getUncachedCoverage() {
         loadVerticalDatum();
         tileSource.setGraph(graph);
         tileSource.setCacheDirectory(cacheDirectory);
@@ -125,9 +117,7 @@ public class NEDGridCoverageFactoryImpl implements ElevationGridCoverageFactory 
         // Make one grid coverage for each NED tile, adding them all to a single UnifiedGridCoverage.
         for (File path : paths) {
             GeotiffGridCoverageFactoryImpl factory = new GeotiffGridCoverageFactoryImpl(path);
-            // TODO might bicubic interpolation give better results?
-            GridCoverage2D regionCoverage = Interpolator2D.create(factory.getGridCoverage(),
-                new InterpolationBilinear());
+            GridCoverage2D regionCoverage = factory.getGridCoverage();
             if (unifiedCoverage == null) {
                 unifiedCoverage = new UnifiedGridCoverage("unified", regionCoverage, datums);
             } else {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDGridCoverageFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDGridCoverageFactoryImpl.java
@@ -34,14 +34,20 @@ public class NEDGridCoverageFactoryImpl implements ElevationGridCoverageFactory 
     /** All tiles for the DEM stitched into a single coverage. */
     UnifiedGridCoverage unifiedCoverage = null;
 
-    private File cacheDirectory;
+    private final File cacheDirectory;
 
-    public NEDTileSource tileSource = new NEDDownloader();
+    public final NEDTileSource tileSource;
 
     private List<VerticalDatum> datums;
 
     public NEDGridCoverageFactoryImpl(File cacheDirectory) {
         this.cacheDirectory = cacheDirectory;
+        this.tileSource = new NEDDownloader();
+    }
+
+    public NEDGridCoverageFactoryImpl(File cacheDirectory, NEDTileSource tileSource) {
+        this.cacheDirectory = cacheDirectory;
+        this.tileSource = tileSource;
     }
 
     private static final String[] DATUM_FILENAMES = {"g2012a00.gtx", "g2012g00.gtx", "g2012h00.gtx", "g2012p00.gtx", "g2012s00.gtx", "g2012u00.gtx"};

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDGridCoverageFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDGridCoverageFactoryImpl.java
@@ -29,11 +29,6 @@ public class NEDGridCoverageFactoryImpl implements ElevationGridCoverageFactory 
 
     private static final Logger LOG = LoggerFactory.getLogger(NEDGridCoverageFactoryImpl.class);
 
-    private Graph graph;
-
-    /** All tiles for the DEM stitched into a single coverage. */
-    UnifiedGridCoverage unifiedCoverage = null;
-
     private final File cacheDirectory;
 
     public final NEDTileSource tileSource;
@@ -110,8 +105,6 @@ public class NEDGridCoverageFactoryImpl implements ElevationGridCoverageFactory 
     /** @return a GeoTools grid coverage for the entire area of interest. */
     public Coverage getGridCoverage() {
         loadVerticalDatum();
-        tileSource.setGraph(graph);
-        tileSource.setCacheDirectory(cacheDirectory);
         List<File> paths = tileSource.getNEDTiles();
         UnifiedGridCoverage unifiedCoverage = null;
         // Make one grid coverage for each NED tile, adding them all to a single UnifiedGridCoverage.
@@ -184,9 +177,12 @@ public class NEDGridCoverageFactoryImpl implements ElevationGridCoverageFactory 
 
     }
 
-    /** Set the graph that will be used to determine the extent of the NED. */
+    /**
+     * Verify that the needed elevation data exists in the cache and if it does not exist, try to download it. The graph
+     * is used to determine the extent of the NED.
+     */
     @Override
-    public void setGraph(Graph graph) {
-        this.graph = graph;
+    public void fetchData(Graph graph) {
+        tileSource.fetchData(graph, cacheDirectory);
     }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
@@ -6,7 +6,6 @@ import com.vividsolutions.jts.index.SpatialIndex;
 import com.vividsolutions.jts.index.strtree.STRtree;
 import org.geotools.coverage.AbstractCoverage;
 import org.geotools.coverage.grid.GridCoverage2D;
-import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.coverage.CannotEvaluateException;
 import org.opengis.coverage.Coverage;
@@ -31,6 +30,13 @@ public class UnifiedGridCoverage extends AbstractCoverage {
     private static final long serialVersionUID = -7798801307087575896L;
 
     private static Logger log = LoggerFactory.getLogger(UnifiedGridCoverage.class);
+
+    /**
+     * A spatial index of the intersection of all regions and datums. For smaller-scale deployments, this spatial index
+     * might perform more slowly than manually iterating over each region and datum. However, in larger regions, this
+     * can result in 20+% more calculations being done. In smaller-scale deployments since the overall time is not as
+     * long, we leave this in here for the benefit of larger regions where this will result in much better performance.
+     */
     private final SpatialIndex datumRegionIndex;
     private ArrayList<Coverage> regions;
     private List<VerticalDatum> datums;
@@ -55,6 +61,9 @@ public class UnifiedGridCoverage extends AbstractCoverage {
         return null;
     }
 
+    /**
+     * Calculate the elevation at a given point
+     */
     public double[] evaluate(DirectPosition point, double[] values) throws CannotEvaluateException {
         double x = point.getOrdinate(0);
         double y = point.getOrdinate(1);
@@ -71,12 +80,12 @@ public class UnifiedGridCoverage extends AbstractCoverage {
                 return result;
             } catch (PointOutsideCoverageException e) {
                 /* not found */
-                log.warn("Point not found: " + point);
+                log.debug("Point not found: " + point);
                 return null;
             }
         }
         /* not found */
-        log.warn("Point not found: " + point);
+        log.debug("Point not found: " + point);
         return null;
     }
     

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
@@ -26,7 +26,9 @@ public class UnifiedGridCoverage extends AbstractCoverage {
     private static final long serialVersionUID = -7798801307087575896L;
 
     private static Logger log = LoggerFactory.getLogger(UnifiedGridCoverage.class);
-    
+
+    private List<GeneralEnvelope> regionEnvelopes;
+
     private ArrayList<Coverage> regions;
 
     private List<VerticalDatum> datums;
@@ -40,6 +42,8 @@ public class UnifiedGridCoverage extends AbstractCoverage {
         super(name, coverage);
         regions = new ArrayList<Coverage>();
         regions.add(coverage);
+        regionEnvelopes = new ArrayList<>();
+        regionEnvelopes.add((GeneralEnvelope) coverage.getEnvelope());
         this.datums = datums;
     }
 
@@ -52,12 +56,13 @@ public class UnifiedGridCoverage extends AbstractCoverage {
     public double[] evaluate(DirectPosition point, double[] values)
             throws PointOutsideCoverageException, CannotEvaluateException {
 
-        for (Coverage region : regions) {
+        for (int i = 0; i < regions.size(); i++) {
             // GeneralEnvelope has a contains method, OpenGIS Envelope does not
-            GeneralEnvelope env = ((GeneralEnvelope)region.getEnvelope());
+            GeneralEnvelope env = regionEnvelopes.get(i);
             // Check envelope to avoid incurring exception construction overhead (PointOutsideCoverageException),
             // especially important when there are many regions.
             if (env.contains(point)) {
+                Coverage region = regions.get(i);
                 double[] result;
                 double x = point.getOrdinate(0);
                 double y = point.getOrdinate(1);
@@ -96,6 +101,7 @@ public class UnifiedGridCoverage extends AbstractCoverage {
 
     public void add(GridCoverage2D regionCoverage) {
         regions.add(regionCoverage);
+        regionEnvelopes.add((GeneralEnvelope) regionCoverage.getEnvelope());
     }
 
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
@@ -74,19 +74,11 @@ public class UnifiedGridCoverage extends AbstractCoverage {
             // Found a match for coverage/datum.
             DatumRegion datumRegion = coverageCandidates.get(0);
             double[] result;
-            try {
-                result = datumRegion.region.evaluate(point, values);
-                result[0] += datumRegion.datum.interpolatedHeight(x, y);
-                return result;
-            } catch (PointOutsideCoverageException e) {
-                /* not found */
-                log.debug("Point not found: " + point);
-                return null;
-            }
+            result = datumRegion.region.evaluate(point, values);
+            result[0] += datumRegion.datum.interpolatedHeight(x, y);
+            return result;
         }
-        /* not found */
-        log.debug("Point not found: " + point);
-        return null;
+        throw new PointOutsideCoverageException("Point not found: " + point);
     }
     
     @Override

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
@@ -34,8 +34,9 @@ public class UnifiedGridCoverage extends AbstractCoverage {
     /**
      * A spatial index of the intersection of all regions and datums. For smaller-scale deployments, this spatial index
      * might perform more slowly than manually iterating over each region and datum. However, in larger regions, this
-     * can result in 20+% more calculations being done. In smaller-scale deployments since the overall time is not as
-     * long, we leave this in here for the benefit of larger regions where this will result in much better performance.
+     * can result in 20+% more calculations being done during the same time compared to the brute-force method. In
+     * smaller-scale deployments since the overall time is not as long, we leave this in here for the benefit of larger
+     * regions where this will result in much better performance.
      */
     private final SpatialIndex datumRegionIndex;
     private ArrayList<Coverage> regions;
@@ -73,8 +74,7 @@ public class UnifiedGridCoverage extends AbstractCoverage {
         if (coverageCandidates.size() > 0) {
             // Found a match for coverage/datum.
             DatumRegion datumRegion = coverageCandidates.get(0);
-            double[] result;
-            result = datumRegion.region.evaluate(point, values);
+            double[] result = datumRegion.region.evaluate(point, values);
             result[0] += datumRegion.datum.interpolatedHeight(x, y);
             return result;
         }

--- a/src/main/java/org/opentripplanner/graph_builder/services/ned/ElevationGridCoverageFactory.java
+++ b/src/main/java/org/opentripplanner/graph_builder/services/ned/ElevationGridCoverageFactory.java
@@ -13,9 +13,11 @@ import org.opentripplanner.routing.graph.Graph;
  */
 
 public interface ElevationGridCoverageFactory {
+    /** Creates a new coverage instance from files already fetched */
     public Coverage getGridCoverage();
 
     public void checkInputs();
 
-    public void setGraph(Graph graph);
+    /** Sets the graph of the factory and initiates the fetching of data that is not present in the cache */
+    public void fetchData(Graph graph);
 }

--- a/src/main/java/org/opentripplanner/graph_builder/services/ned/NEDTileSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/services/ned/NEDTileSource.java
@@ -12,15 +12,12 @@ import java.util.List;
  */
 public interface NEDTileSource {
 
-    public abstract void setGraph(Graph graph);
-
     /**
-     * The cache directory stores NED tiles.  It is crucial that this be somewhere permanent
-     * with plenty of disk space.  Don't use /tmp -- the downloading process takes a long time
+     * Fetches all of the required data and stores it in the specified cache directory. It is crucial that this be
+     * somewhere permanent with plenty of disk space.  Don't use /tmp -- the downloading process takes a long time
      * and you don't want to repeat it if at all possible.
-     * @param cacheDirectory
      */
-    public abstract void setCacheDirectory(File cacheDirectory);
+    public abstract void fetchData(Graph graph, File cacheDirectory);
 
     /**
      * Download all the NED tiles into the cache.

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetWithElevationEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetWithElevationEdge.java
@@ -90,6 +90,8 @@ public class StreetWithElevationEdge extends StreetEdge {
         return CompactElevationProfile.uncompactElevationProfile(packedElevationProfile);
     }
 
+    public boolean hasPackedElevationProfile () { return packedElevationProfile != null; }
+
     @Override
     public boolean isElevationFlattened() {
         return flattened;

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -205,12 +205,6 @@ public class GraphBuilderParameters {
     public boolean includeEllipsoidToGeoidDifference;
 
     /**
-     * The number of significant digits to use when caching Ellipsoid to Geiod difference values. The defualt is 0 and
-     * is capped at 2.
-     */
-    public int geoidDifferenceSignficantDigits;
-
-    /**
      * Set all parameters from the given Jackson JSON tree, applying defaults.
      * Supplying MissingNode.getInstance() will cause all the defaults to be applied.
      * This could be done automatically with the "reflective query scraper" but it's less type safe and less clear.
@@ -250,7 +244,6 @@ public class GraphBuilderParameters {
         readCachedElevations = config.path("readCachedElevations").asBoolean(true);
         writeCachedElevations = config.path("writeCachedElevations").asBoolean(false);
         includeEllipsoidToGeoidDifference = config.path("includeEllipsoidToGeoidDifference").asBoolean(false);
-        geoidDifferenceSignficantDigits = Math.min(2, config.path("geoidDifferenceSignficantDigits").asInt(0));
     }
 
 

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -186,6 +186,13 @@ public class GraphBuilderParameters {
     public String micromobilityDropoffRestrictionsUrlOrFile;
 
     /**
+     * When set to true (it is by default), this will create a file after building elevations with information about
+     * all the elevations organized by coordinates. Subsequent graph builds will reuse the data in this file to avoid
+     * recalculating all the elevation data again.
+     */
+    public boolean cacheElevations;
+
+    /**
      * Set all parameters from the given Jackson JSON tree, applying defaults.
      * Supplying MissingNode.getInstance() will cause all the defaults to be applied.
      * This could be done automatically with the "reflective query scraper" but it's less type safe and less clear.
@@ -222,6 +229,7 @@ public class GraphBuilderParameters {
         extraEdgesStopPlatformLink = config.path("extraEdgesStopPlatformLink").asBoolean(false);
         micromobilityTravelRestrictionsUrlOrFile = config.path("micromobilityTravelRestrictionsUrlOrFile").asText();
         micromobilityDropoffRestrictionsUrlOrFile = config.path("micromobilityDropoffRestrictionsUrlOrFile").asText();
+        cacheElevations = config.path("cacheElevations").asBoolean(true);
     }
 
 

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.standalone;
 
+import org.opentripplanner.api.common.RoutingResource;
 import org.opentripplanner.graph_builder.module.osm.WayPropertySetSource;
 import org.opentripplanner.graph_builder.services.osm.CustomNamer;
 import org.opentripplanner.profile.StopClusterMode;
@@ -201,6 +202,10 @@ public class GraphBuilderParameters {
     /**
      * When set to true (it is false by default), the elevation module will include the Ellipsoid to Geiod difference in
      * the calculations of every point along every StreetWithElevationEdge in the graph.
+     *
+     * NOTE: if this is set to true for graph building, make sure to not set the value of
+     * {@link RoutingResource#geoidElevation} to true otherwise OTP will add this geoid value again to all of the
+     * elevation values in the street edges.
      */
     public boolean includeEllipsoidToGeoidDifference;
 

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -199,6 +199,18 @@ public class GraphBuilderParameters {
     public boolean writeCachedElevations;
 
     /**
+     * When set to true (it is false by default), the elevation module will include the Ellipsoid to Geiod difference in
+     * the calculations of every point along every StreetWithElevationEdge in the graph.
+     */
+    public boolean includeEllipsoidToGeoidDifference;
+
+    /**
+     * The number of significant digits to use when caching Ellipsoid to Geiod difference values. The defualt is 0 and
+     * is capped at 2.
+     */
+    public int geoidDifferenceSignficantDigits;
+
+    /**
      * Set all parameters from the given Jackson JSON tree, applying defaults.
      * Supplying MissingNode.getInstance() will cause all the defaults to be applied.
      * This could be done automatically with the "reflective query scraper" but it's less type safe and less clear.
@@ -237,6 +249,8 @@ public class GraphBuilderParameters {
         micromobilityDropoffRestrictionsUrlOrFile = config.path("micromobilityDropoffRestrictionsUrlOrFile").asText();
         readCachedElevations = config.path("readCachedElevations").asBoolean(true);
         writeCachedElevations = config.path("writeCachedElevations").asBoolean(false);
+        includeEllipsoidToGeoidDifference = config.path("includeEllipsoidToGeoidDifference").asBoolean(false);
+        geoidDifferenceSignficantDigits = Math.min(2, config.path("geoidDifferenceSignficantDigits").asInt(0));
     }
 
 

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -186,11 +186,17 @@ public class GraphBuilderParameters {
     public String micromobilityDropoffRestrictionsUrlOrFile;
 
     /**
-     * When set to true (it is by default), this will create a file after building elevations with information about
-     * all the elevations organized by coordinates. Subsequent graph builds will reuse the data in this file to avoid
-     * recalculating all the elevation data again.
+     * When set to true (it is by default), the elevation module will attempt to read this file in order to reuse
+     * calculations of elevation data for various coordinate sequences instead of recalculating them all over again.
      */
-    public boolean cacheElevations;
+    public boolean readCachedElevations;
+
+    /**
+     * When set to true (it is false by default), the elevation module will create a file of a lookup map of the
+     * LineStrings and the corresponding calculated elevation data for those coordinates. Subsequent graph builds can
+     * reuse the data in this file to avoid recalculating all the elevation data again.
+     */
+    public boolean writeCachedElevations;
 
     /**
      * Set all parameters from the given Jackson JSON tree, applying defaults.
@@ -229,7 +235,8 @@ public class GraphBuilderParameters {
         extraEdgesStopPlatformLink = config.path("extraEdgesStopPlatformLink").asBoolean(false);
         micromobilityTravelRestrictionsUrlOrFile = config.path("micromobilityTravelRestrictionsUrlOrFile").asText();
         micromobilityDropoffRestrictionsUrlOrFile = config.path("micromobilityDropoffRestrictionsUrlOrFile").asText();
-        cacheElevations = config.path("cacheElevations").asBoolean(true);
+        readCachedElevations = config.path("readCachedElevations").asBoolean(true);
+        writeCachedElevations = config.path("writeCachedElevations").asBoolean(false);
     }
 
 

--- a/src/main/java/org/opentripplanner/util/ElevationUtils.java
+++ b/src/main/java/org/opentripplanner/util/ElevationUtils.java
@@ -26,7 +26,9 @@ public class ElevationUtils {
     }
 
     /**
-     * Computes the difference between the ellipsoid and geoid at a specified lat/lon using Geotools EarthGravitationalModel
+     * Computes the difference between the ellipsoid and geoid at a specified lat/lon using Geotools
+     * EarthGravitationalModel. For unknown reasons, this method can produce incorrect results if called at the same
+     * time from multiple threads, so the method has been made synchronized.
      *
      * @param lat
      * @param lon
@@ -34,8 +36,7 @@ public class ElevationUtils {
      * @throws FactoryException
      * @throws TransformException
      */
-
-    public static double computeEllipsoidToGeoidDifference(double lat, double lon) throws TransformException {
+    public static synchronized double computeEllipsoidToGeoidDifference(double lat, double lon) throws TransformException {
         // Compute the offset
         DirectPosition3D dest = new DirectPosition3D();
         mt.transform(new DirectPosition3D(lon, lat, 0), dest);

--- a/src/main/java/org/opentripplanner/util/ElevationUtils.java
+++ b/src/main/java/org/opentripplanner/util/ElevationUtils.java
@@ -13,6 +13,18 @@ import org.opengis.referencing.operation.TransformException;
 
 public class ElevationUtils {
 
+    // Set up a MathTransform based on the EarthGravitationalModel
+    private static MathTransform mt;
+    static {
+        try {
+            mt = new DefaultMathTransformFactory().createParameterizedTransform(
+                new EarthGravitationalModel.Provider().getParameters().createValue()
+            );
+        } catch (FactoryException e) {
+            e.printStackTrace();
+        }
+    }
+
     /**
      * Computes the difference between the ellipsoid and geoid at a specified lat/lon using Geotools EarthGravitationalModel
      *
@@ -23,12 +35,7 @@ public class ElevationUtils {
      * @throws TransformException
      */
 
-    public static double computeEllipsoidToGeoidDifference(double lat, double lon) throws FactoryException, TransformException {
-        // Set up a MathTransform based on the EarthGravitationalModel
-        EarthGravitationalModel.Provider provider = new EarthGravitationalModel.Provider();
-        DefaultMathTransformFactory factory = new DefaultMathTransformFactory();
-        MathTransform mt = factory.createParameterizedTransform(provider.getParameters().createValue());
-
+    public static double computeEllipsoidToGeoidDifference(double lat, double lon) throws TransformException {
         // Compute the offset
         DirectPosition3D dest = new DirectPosition3D();
         mt.transform(new DirectPosition3D(lon, lat, 0), dest);

--- a/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
@@ -102,6 +102,6 @@ public class ElevationModuleTest {
 
         // verify that elevation data has been set on the StreetWithElevationEdge
         assertNotNull(edge.getElevationProfile());
-        assertEquals(114.71, edge.getElevationProfile().getY(1), 0.1);
+        assertEquals(133.95, edge.getElevationProfile().getY(1), 0.1);
     }
 }

--- a/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
@@ -1,0 +1,108 @@
+package org.opentripplanner.graph_builder.module;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.LineString;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.opentripplanner.common.geometry.GeometryUtils;
+import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
+import org.opentripplanner.graph_builder.module.ned.DegreeGridNEDTileSource;
+import org.opentripplanner.graph_builder.module.ned.ElevationModule;
+import org.opentripplanner.graph_builder.module.ned.NEDGridCoverageFactoryImpl;
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+import org.opentripplanner.routing.edgetype.StreetWithElevationEdge;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.vertextype.OsmVertex;
+import org.opentripplanner.routing.vertextype.StreetVertex;
+import org.opentripplanner.standalone.S3BucketConfig;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ElevationModuleTest {
+
+    /**
+     * Tests whether elevation can be properly set using s3 bucket tiles. This test is ignored by default because it
+     * would require checking in a file to this repository that is about 450mb large.
+     *
+     * To setup this test, copy everything in the /var/otp/cache/ned into
+     * .../src/test/resources/org/opentripplanner/graph_builder/module/ned/
+     */
+    @Test
+    @Ignore
+    public void testSetElevationOnEdgesUsingS3BucketTiles() {
+        // create a graph with a StreetWithElevationEdge
+        Graph graph = new Graph();
+        OsmVertex from = new OsmVertex(graph, "from", -122.6932051, 45.5122964, 40513757);
+        OsmVertex to = new OsmVertex(graph, "to", -122.6903532, 45.5115309, 1677595882);
+        LineString geometry = GeometryUtils.makeLineString(
+            -122.6932051,
+            45.5122964,
+            -122.6931118,
+            45.5122687,
+            -122.692677,
+            45.512204,
+            -122.692443,
+            45.512142,
+            -122.6923995,
+            45.5121229,
+            -122.692359,
+            45.512096,
+            -122.692294,
+            45.512024,
+            -122.692219,
+            45.511961,
+            -122.69212,
+            45.511908,
+            -122.6920612,
+            45.5118889,
+            -122.6920047,
+            45.5118749,
+            -122.6919636,
+            45.5118711,
+            -122.6918977,
+            45.5118684,
+            -122.6918211,
+            45.5118662,
+            -122.6917612,
+            45.5118599,
+            -122.6916928,
+            45.5118503,
+            -122.691241,
+            45.511774,
+            -122.6903532,
+            45.5115309
+        );
+        Coordinate[] coordinates = geometry.getCoordinates();
+        double length = 0;
+        for (int i = 1; i < coordinates.length; ++i) {
+            length += SphericalDistanceLibrary.distance(coordinates[i - 1], coordinates[i]);
+        }
+        StreetWithElevationEdge edge = new StreetWithElevationEdge(
+            from,
+            to,
+            geometry,
+            "Southwest College St",
+            length,
+            StreetTraversalPermission.ALL,
+            false
+        );
+
+        // create the elevation module
+        File cacheDirectory = new File(ElevationModuleTest.class.getResource("ned").getFile());
+        DegreeGridNEDTileSource awsTileSource = new DegreeGridNEDTileSource();
+        NEDGridCoverageFactoryImpl gcf = new NEDGridCoverageFactoryImpl(cacheDirectory);
+        gcf.tileSource = awsTileSource;
+        ElevationModule elevationModule = new ElevationModule(gcf);
+
+        // build to graph to execute the elevation module
+        elevationModule.checkInputs();
+        elevationModule.buildGraph(graph, new GraphBuilderModuleSummary(elevationModule));
+
+        // verify that elevation data has been set on the StreetWithElevationEdge
+        assertNotNull(edge.getElevationProfile());
+        assertEquals(114.71, edge.getElevationProfile().getY(1), 0.1);
+    }
+}

--- a/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
@@ -93,8 +93,7 @@ public class ElevationModuleTest {
         // create the elevation module
         File cacheDirectory = new File(ElevationModuleTest.class.getResource("ned").getFile());
         DegreeGridNEDTileSource awsTileSource = new DegreeGridNEDTileSource();
-        NEDGridCoverageFactoryImpl gcf = new NEDGridCoverageFactoryImpl(cacheDirectory);
-        gcf.tileSource = awsTileSource;
+        NEDGridCoverageFactoryImpl gcf = new NEDGridCoverageFactoryImpl(cacheDirectory, awsTileSource);
         ElevationModule elevationModule = new ElevationModule(gcf);
 
         // build to graph to execute the elevation module


### PR DESCRIPTION
This PR dramatically speeds up the calculations in the ElevationModule of the graph builder modules. It does so by:

- Optimizing as many calculations of elevations for a street edge as possible.
- Adding the ability to read/write cached elevation data
  - After graph building, a file with a lookup of the cached elevation for a coordinate sequence can be written
  - In subsequent graph builds, this file can be loaded and the cached data can be used.
  - custom graph build parameters can be entered to enable or disable reading or writing of this data. The default is to read, but not to write.

In addition to the performance improvements, this PR also has changes that:
- tolerate areas where elevation tiles are unavailable.
- refactor a few elevation classes to simplify constructors
- Add a simple test of the elevation module
- adds documentation of how to optimize elevation calculations