### PR TITLE
bump r5 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -823,7 +823,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>r5</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
+            <version>4.1.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-simple</artifactId>


### PR DESCRIPTION
This is a bit of a quick fix for the `ibi-dev` branch to ensure that Travis builds work ok. It appears that the maven repo with snapshots of conveyal/r5 has been removed, so this just bumps the r5 version to [4.1.0](https://github.com/conveyal/r5/releases/tag/v4.1.0) so that the dependency is located successfully.