### PR TITLE
Update ibi-dev with dev-1.x (maven repo fixes)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -420,7 +420,7 @@
         <repository>
             <id>osgeo</id>
             <name>Open Source Geospatial Foundation Repository</name>
-            <url>https://download.osgeo.org/webdav/geotools/</url>
+            <url>https://repo.osgeo.org/repository/release/</url>
         </repository>
         <repository>
             <id>axis</id>

--- a/pom.xml
+++ b/pom.xml
@@ -440,7 +440,7 @@
         <repository>
             <id>onebusaway-releases</id>
             <name>Onebusaway Releases Repo</name>
-            <url>http://nexus.onebusaway.org/content/repositories/releases/</url>
+            <url>https://repo.camsys-apps.com/releases/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
This updated ibi-group/ibi-dev with the latest dev-1.x because there are patches to pom.xml that fix the build.