### PR TITLE
Properly set the backMode after car and vehicle rentals are ended

### DIFF
--- a/src/main/java/org/opentripplanner/routing/core/StateData.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateData.java
@@ -76,6 +76,10 @@ public class StateData implements Cloneable {
 
     protected ServiceDay serviceDay;
 
+    /**
+     * The mode of transit to use when not traveling on transit. This should be updated each time transitions happen to
+     * other modes such as during parking a car at a park and ride or dropping off a bike rental.
+     */
     protected TraverseMode nonTransitMode;
 
     /**
@@ -93,7 +97,7 @@ public class StateData implements Cloneable {
     protected int lastNextArrivalDelta;
 
     /**
-     * The mode that was used to traverse the backEdge
+     * The mode that was used to traverse the state's backEdge
      */
     protected TraverseMode backMode;
 

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -593,6 +593,7 @@ public class StateEditor {
     public void endCarRenting() {
         cloneStateDataAsNeeded();
         child.stateData.usingRentedCar = false;
+        child.stateData.backMode = TraverseMode.WALK;
         child.stateData.nonTransitMode = TraverseMode.WALK;
     }
 
@@ -636,6 +637,7 @@ public class StateEditor {
     public void endVehicleRenting() {
         cloneStateDataAsNeeded();
         child.stateData.usingRentedVehicle = false;
+        child.stateData.backMode = TraverseMode.WALK;
         child.stateData.nonTransitMode = TraverseMode.WALK;
     }
 


### PR DESCRIPTION
Fixes https://github.com/ibi-group/trimet-mod-otp/issues/262

During transitions of state during the shortest path search, the `stateData.backMode` was not properly set upon ending a car or vehicle rental. This caused the issue described above which resulted in the `rentedCar` and `rentedVehicle` properties to not be properly set on some legs.