### PR TITLE
Reverse optimization fixes for new modes

### DIFF
--- a/src/main/java/org/opentripplanner/routing/core/State.java
+++ b/src/main/java/org/opentripplanner/routing/core/State.java
@@ -629,8 +629,8 @@ public class State implements Cloneable {
         }
         newState.stateData.usingRentedVehicle = stateData.usingRentedVehicle;
         // if the original request options was depart At, there is a chance that the new reversed state could
-        // immediately begin renting a car even if it didn't end that way. If the original trip didn't end this way, the
-        // car rental must be undone.
+        // immediately begin renting a vehicle even if it didn't end that way. If the original trip didn't end this way,
+        // the vehicle rental must be undone.
         if (!stateData.opt.arriveBy && !stateData.usingRentedVehicle) {
             newState.stateData.nonTransitMode = TraverseMode.WALK;
             newState.stateData.hasRentedVehiclePreTransit = false;

--- a/src/main/java/org/opentripplanner/routing/core/StateData.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateData.java
@@ -77,8 +77,8 @@ public class StateData implements Cloneable {
     protected ServiceDay serviceDay;
 
     /**
-     * The mode of transit to use when not traveling on transit. This should be updated each time transitions happen to
-     * other modes such as during parking a car at a park and ride or dropping off a bike rental.
+     * The mode of travel to use when not traveling on transit. This should be updated each time transitions happen to
+     * other modes such as parking a car at a park and ride or dropping off a bike rental.
      */
     protected TraverseMode nonTransitMode;
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/RentACarOffEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/RentACarOffEdge.java
@@ -39,7 +39,11 @@ public class RentACarOffEdge extends RentACarAbstractEdge {
     public State traverse(State s0) {
         RoutingRequest options = s0.getOptions();
 
-        if (!s0.isCarRentalDropoffAllowed(!station.isBorderDropoff))
+        // check if the current state would allow a car rental dropoff. In certain cases, RentACarOffEdges can be
+        // created when creating border drop-off stations. In these cases we still want to specify that the car is
+        // being dropped off at a designated area in order for reverse optimization searches to recognize the station
+        // when approaching from the out-of-boundary side.
+        if (!s0.isCarRentalDropoffAllowed(true))
             return null;
 
         // make sure there is at least one spot to park at the station

--- a/src/main/java/org/opentripplanner/routing/edgetype/RentAVehicleOffEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/RentAVehicleOffEdge.java
@@ -39,8 +39,11 @@ public class RentAVehicleOffEdge extends RentAVehicleAbstractEdge {
     public State traverse(State s0) {
         RoutingRequest options = s0.getOptions();
 
-        // check if the current state would allow a vehicle dropoff
-        if (!s0.isVehicleRentalDropoffAllowed(!station.isBorderDropoff)) {
+        // check if the current state would allow a vehicle dropoff. In certain cases, RentAVehicleOffEdges can be
+        // created when creating border drop-off stations. In these cases we still want to specify that the vehicle is
+        // being dropped off at a designated area in order for reverse optimization searches to recognize the station
+        // when approaching from the out-of-boundary side.
+        if (!s0.isVehicleRentalDropoffAllowed(true)) {
             // something about the current state makes dropping off a vehicle not possible, return null.
             return null;
         }


### PR DESCRIPTION
I didn't quite know how this reverse optimization thing worked when I wrote the code for all these modes, but now I do. 🤯 

This PR makes it some the CAR_HAIL, CAR_RENT and MICROMOBILITY_RENT modes will reverse optimize. Reverse optimize means that after a shortest path is found, the states are retraversed in reverse in order to find more appropriate times for initially departing for depart at queries or for the final arrival in arrive by queries.

Fixes https://github.com/ibi-group/OpenTripPlanner/issues/14

See this [Micromobility rental trip on TriMet's newplanner](https://newplanner.trimet.org/map/#/?ui_activeSearch=xvullzmj6&ui_activeItinerary=0&fromPlace=2455%20NW%20Overton%20St%2C%20Portland%2C%20OR%2C%20USA%2097210%3A%3A45.532086387683606%2C-122.70179794463218&toPlace=3037%20SE%20Pine%20St%2C%20Portland%2C%20OR%2C%20USA%2097214%3A%3A45.52090198266666%2C-122.63418673927467&date=2020-06-20&time=02%3A20&arriveBy=false&mode=BUS%2CTRAM%2CRAIL%2CGONDOLA%2CMICROMOBILITY_RENT&showIntermediateStops=true&optimize=QUICK&maxWalkDistance=4828&maxEScooterDistance=4828&ignoreRealtimeUpdates=true&companies=BOLT%2CCLEVR%2CLIME%2CRAZOR%2CSHARED%2CSPIN%2CBIRD). As you can see, the pre-transit segment leaves exactly at the departure time and then there is an 80 minute wait for transit.

Compare the same trip to [this one on trimet-mod-dev](https://trimet-mod-dev.ibi-transit.com/#/?ui_activeSearch=xvullzmj6&ui_activeItinerary=0&fromPlace=2455%20NW%20Overton%20St%2C%20Portland%2C%20OR%2C%20USA%2097210%3A%3A45.532086387683606%2C-122.70179794463218&toPlace=3037%20SE%20Pine%20St%2C%20Portland%2C%20OR%2C%20USA%2097214%3A%3A45.52090198266666%2C-122.63418673927467&date=2020-06-20&time=02%3A20&arriveBy=false&mode=BUS%2CTRAM%2CRAIL%2CGONDOLA%2CMICROMOBILITY_RENT&showIntermediateStops=true&optimize=QUICK&maxWalkDistance=4828&maxEScooterDistance=4828&ignoreRealtimeUpdates=true&companies=BOLT%2CCLEVR%2CLIME%2CRAZOR%2CSHARED%2CSPIN%2CBIRD) which has a later initial departure time.