### PR TITLE
Filter out ways with "planned" tag

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMFilter.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMFilter.java
@@ -36,6 +36,7 @@ public class OSMFilter {
             if(
                     highway.equals("conveyer") ||
                     highway.equals("proposed") ||
+                    highway.equals("planned") ||
                     highway.equals("construction") ||
                     highway.equals("razed") ||
                     highway.equals("raceway") ||


### PR DESCRIPTION
This PR adds the tag of `"highway"="planned"` to the list of filters that will result in a OSM way not being included as a routeable way. There are significantly fewer of these than the `"highway"="proposed"`, but they do exist.