### PR TITLE
Also catch KryoExceptions when attempting to read in cached elevation

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.graph_builder.module.ned;
 
 import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import org.locationtech.jts.geom.Coordinate;

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.graph_builder.module.ned;
 
 import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import org.locationtech.jts.geom.Coordinate;
@@ -178,7 +179,7 @@ public class ElevationModule implements GraphBuilderModule {
                 Input input = new Input(new FileInputStream(cachedElevationsFile));
                 cachedElevations = (HashMap<String, PackedCoordinateSequence>) kryo.readClassAndObject(input);
                 log.info("Cached elevation data loaded into memory!");
-            } catch (FileNotFoundException e) {
+            } catch (KryoException | FileNotFoundException e) {
                 log.warn(graph.addBuilderAnnotation(new Graphwide(
                     String.format("Cached elevations file could not be read in due to error: %s!", e.getMessage()))));
             }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -179,9 +179,17 @@ public class ElevationModule implements GraphBuilderModule {
                 Input input = new Input(new FileInputStream(cachedElevationsFile));
                 cachedElevations = (HashMap<String, PackedCoordinateSequence>) kryo.readClassAndObject(input);
                 log.info("Cached elevation data loaded into memory!");
-            } catch (KryoException | FileNotFoundException e) {
-                log.warn(graph.addBuilderAnnotation(new Graphwide(
-                    String.format("Cached elevations file could not be read in due to error: %s!", e.getMessage()))));
+            } catch (Exception e) {
+                log.warn(
+                    graph.addBuilderAnnotation(
+                        new Graphwide(
+                            String.format(
+                                "Cached elevations file could not be read in due to error: %s!",
+                                e.getMessage()
+                            )
+                        )
+                    )
+                );
             }
         }
         log.info(demPrepareTask.finish());


### PR DESCRIPTION
Sometimes a cached elevation file might not be written in the Kryo format, so this PR makes it so OTP won't crash when that happens. If a cached elevation file isn't written in the Kryo format, it is expected that a new file will be written to replace it, so this facilitates that process.