### PR TITLE
WayPropertySet optimization

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -778,7 +778,11 @@ public class OpenStreetMapModule implements GraphBuilderModule {
          * restricted area.
          */
         private void applyMicromobilityRestrictions(StreetEdge streetEdge) {
-            if (streetEdge != null) {
+            if (
+                streetEdge != null &&
+                    restrictedMicromobilityTravelGeometry != null &&
+                    restrictedMicromobilityDropoffGeometry != null
+            ) {
                 Geometry streetEdgeGeometry = streetEdge.getGeometry();
                 if (
                     restrictedMicromobilityTravelGeometry != null &&

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -780,8 +780,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
         private void applyMicromobilityRestrictions(StreetEdge streetEdge) {
             if (
                 streetEdge != null &&
-                    restrictedMicromobilityTravelGeometry != null &&
-                    restrictedMicromobilityDropoffGeometry != null
+                    (restrictedMicromobilityTravelGeometry != null || restrictedMicromobilityDropoffGeometry != null)
             ) {
                 Geometry streetEdgeGeometry = streetEdge.getGeometry();
                 if (

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -161,6 +161,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
     public void setDefaultWayPropertySetSource(WayPropertySetSource source) {
         wayPropertySet = new WayPropertySet();
         source.populateProperties(wayPropertySet);
+        wayPropertySet.index();
     }
 
     /**
@@ -614,13 +615,14 @@ public class OpenStreetMapModule implements GraphBuilderModule {
 
             /* build the street segment graph from OSM ways */
             long wayIndex = 0;
-            long wayCount = osmdb.getWays().size();
+            Collection <OSMWay> ways = osmdb.getWays();
+            long wayCount = ways.size();
 
             WAY:
-            for (OSMWay way : osmdb.getWays()) {
+            for (OSMWay way : ways) {
 
-                if (wayIndex % 10000 == 0)
-                    LOG.debug("ways=" + wayIndex + "/" + wayCount);
+                if (wayIndex % 50000 == 0)
+                    LOG.info("ways=" + wayIndex + "/" + wayCount);
                 wayIndex++;
 
                 WayProperties wayData = wayPropertySet.getDataForWay(way);

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
@@ -82,7 +82,7 @@ public class WayPropertySet {
     }
 
     /**
-     * Initializes lookups and Indexes for quick lookup of applicable values for way properties and car speeds. This
+     * Initializes lookups and indexes for quick lookup of applicable values for way properties and car speeds. This
      * function must be called before looking up way properties and car speeds for ways in order for those caches to be
      * properly initialized.
      */
@@ -117,7 +117,7 @@ public class WayPropertySet {
      * @param way The way from which to calculate a key
      * @param possibleTagValues The possible tag values that would apply for this way
      */
-    private String getKeyFromApplicableTags (OSMWithTags way, HashSet possibleTagValues) {
+    private String getKeyFromApplicableTags(OSMWithTags way, HashSet possibleTagValues) {
         List<String> applicableTagValues = new ArrayList<>();
         Map<String, String> wayTags = way.getTags();
         if (wayTags == null) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
@@ -182,8 +182,9 @@ public class WayPropertySet {
     public WayProperties getDataForWay(OSMWithTags way) {
         String wayPropertiesKey = getKeyFromApplicableTags(way, possibleWayPropertyTagValues);
         // check if lookup key found
-        if (wayPropertyLookup.containsKey(wayPropertiesKey)) {
-            return wayPropertyLookup.get(wayPropertiesKey);
+        WayProperties cachedWayProperties = wayPropertyLookup.get(wayPropertiesKey);
+        if (cachedWayProperties != null) {
+            return cachedWayProperties;
         }
 
         WayProperties leftResult = defaultProperties;
@@ -303,8 +304,9 @@ public class WayPropertySet {
         // also append back value
         wayPropertiesKey = String.format("%s;%s=%b", wayPropertiesKey, "back=", back);
         // check if lookup key found
-        if (carSpeedLookup.containsKey(wayPropertiesKey)) {
-            return carSpeedLookup.get(wayPropertiesKey);
+        Float cachedSpeed = carSpeedLookup.get(wayPropertiesKey);
+        if (cachedSpeed != null) {
+            return cachedSpeed;
         }
 
         Float speed = calculateCarSpeedForWay(way, back);

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
@@ -21,8 +21,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.Collections.sort;
 
@@ -61,7 +59,11 @@ public class WayPropertySet {
 
     private HashMap<String, WayProperties> wayPropertyLookup;
 
-    private HashSet<Object> possibleWayTagValues;
+    private HashSet<String> possibleWayPropertyTagValues;
+
+    private HashMap<String, Float> carSpeedLookup;
+
+    private HashSet<String> possibleCarSpeedTagValues;
 
     public WayPropertySet() {
         /* sensible defaults */
@@ -80,16 +82,97 @@ public class WayPropertySet {
     }
 
     /**
-     * Initializes lookups and Indexes various sets for quick lookup of applicable values
+     * Initializes lookups and Indexes for quick lookup of applicable values for way properties and car speeds. This
+     * function must be called before looking up way properties and car speeds for ways in order for those caches to be
+     * properly initialized.
      */
     public void index() {
+        // index for way properties
         wayPropertyLookup = new HashMap<>();
-        possibleWayTagValues = new HashSet<>();
+        possibleWayPropertyTagValues = new HashSet<>();
         for (WayPropertyPicker wayProperty : wayProperties) {
             for (P2<String> kvpair : wayProperty.getSpecifier().kvpairs) {
-                possibleWayTagValues.add(String.format("%s=%s", kvpair.first, kvpair.second));
+                possibleWayPropertyTagValues.add(String.format("%s=%s", kvpair.first, kvpair.second));
             }
         }
+
+        // index for car speed lookup
+        carSpeedLookup = new HashMap<>();
+        possibleCarSpeedTagValues = new HashSet<>();
+        for (SpeedPicker speedPicker : speedPickers) {
+            for (P2<String> kvpair : speedPicker.specifier.kvpairs) {
+                possibleCarSpeedTagValues.add(String.format("%s=%s", kvpair.first, kvpair.second));
+            }
+        }
+        // also add manual search terms from getCarSpeedForWay method
+        possibleCarSpeedTagValues.add("maxspeed:motorcar=*");
+        possibleCarSpeedTagValues.add("maxspeed:forward=*");
+        possibleCarSpeedTagValues.add("maxspeed:reverse=*");
+        possibleCarSpeedTagValues.add("maxspeed:lanes=*");
+        possibleCarSpeedTagValues.add("maxspeed=*");
+    }
+
+    /**
+     * compute lookup key for way based on applicable tags/values
+     * @param way The way from which to calculate a key
+     * @param possibleTagValues The possible tag values that would apply for this way
+     */
+    private String getKeyFromApplicableTags (OSMWithTags way, HashSet possibleTagValues) {
+        List<String> applicableTagValues = new ArrayList<>();
+        Map<String, String> wayTags = way.getTags();
+        if (wayTags == null) {
+            // no tags added to way. Probably occurs only during testing.
+            return "";
+        }
+        for (Entry<String, String> wayTagValue : wayTags.entrySet()) {
+            String tag = wayTagValue.getKey();
+            String value = wayTagValue.getValue();
+            String tagValue = String.format("%s=%s", tag, value);
+
+            // create list of tags to see if any of them are in applicable list
+            List<String> possibleMatches = new ArrayList<>();
+
+            // add exact match use case
+            possibleMatches.add(tagValue);
+
+            // add wildcard value for tag
+            possibleMatches.add(String.format("%s=*", tag));
+
+            // if value contains a colon and thus possibly a suffix (such as surface=cobblestone:flattened), use the
+            // root tag value
+            String rootValue = null;
+            if (value.contains(":")) {
+                rootValue = value.split(":", 2)[0];
+                // add exact tag wth root value
+                possibleMatches.add(String.format("%s=%s", tag, rootValue));
+            }
+
+            // if tag contains a colon and thus a suffix (such as cycleway:right), use the root tag key to check if
+            // there is a match
+            if (tag.contains(":")) {
+                String rootTag = tag.split(":", 2)[0];
+                // add both exact and wilcard tag/values
+                possibleMatches.add(String.format("%s=%s", rootTag, value));
+                possibleMatches.add(String.format("%s=*", rootTag));
+
+                // also add rootValue if applicable
+                if (rootValue != null) {
+                    possibleMatches.add(String.format("%s=%s", rootTag, rootValue));
+                }
+            }
+
+            for (String possibleMatch : possibleMatches) {
+                if (possibleTagValues.contains(possibleMatch)) {
+                    // add the exact tag value to make sure cache key is for this exact set of tag/values
+                    applicableTagValues.add(tagValue);
+                    // break as there is no need to search for other possibilities
+                    break;
+                }
+            }
+        }
+        // sort values to make deterministic key
+        sort(applicableTagValues);
+        return String.join(";", applicableTagValues);
     }
 
     /**
@@ -97,20 +180,7 @@ public class WayPropertySet {
      * will have their safety values applied if they match at all.
      */
     public WayProperties getDataForWay(OSMWithTags way) {
-        // compute lookup key for way based on applicable tags/values
-        List<String> applicableTagValues = new ArrayList<>();
-        for (Entry<String, String> wayTagValue : way.getTags().entrySet()) {
-            // if tag/value exists in way properties, add to list of matches
-            String tagValue = String.format("%s=%s", wayTagValue.getKey(), wayTagValue.getValue());
-            String wildcardTag = String.format("%s=*", wayTagValue.getKey());
-            if (possibleWayTagValues.contains(tagValue) || possibleWayTagValues.contains(wildcardTag)) {
-                applicableTagValues.add(tagValue);
-            }
-        }
-        // sort values to make deterministic key
-        sort(applicableTagValues);
-        String wayPropertiesKey = String.join(";", applicableTagValues);
-
+        String wayPropertiesKey = getKeyFromApplicableTags(way, possibleWayPropertyTagValues);
         // check if lookup key found
         if (wayPropertyLookup.containsKey(wayPropertiesKey)) {
             return wayPropertyLookup.get(wayPropertiesKey);
@@ -168,6 +238,13 @@ public class WayPropertySet {
         return result;
     }
 
+    /**
+     * Returns the current way property lookup hashmap. Used for testing only.
+     */
+    public HashMap<String, WayProperties> getWayPropertyLookup () {
+        return wayPropertyLookup;
+    }
+
     private String dumpTags(OSMWithTags way) {
         /* generate warning message */
         String all_tags = null;
@@ -218,9 +295,27 @@ public class WayPropertySet {
     }
     
     /**
-     * Calculate the automobile speed, in meters per second, for this way.
+     * Get the automobile speed, in meters per second, for this way. Try to get value from the cache, otherwise
+     * calculate and store in cache.
      */
     public float getCarSpeedForWay(OSMWithTags way, boolean back) {
+        String wayPropertiesKey = getKeyFromApplicableTags(way, possibleCarSpeedTagValues);
+        // also append back value
+        wayPropertiesKey = String.format("%s;%s=%b", wayPropertiesKey, "back=", back);
+        // check if lookup key found
+        if (carSpeedLookup.containsKey(wayPropertiesKey)) {
+            return carSpeedLookup.get(wayPropertiesKey);
+        }
+
+        Float speed = calculateCarSpeedForWay(way, back);
+        carSpeedLookup.put(wayPropertiesKey, speed);
+        return speed;
+    }
+
+    /**
+     * Calculate the automobile speed, in meters per second, for this way.
+     */
+    private float calculateCarSpeedForWay(OSMWithTags way, boolean back) {
         // first, check for maxspeed tags
         Float speed = null;
         Float currentSpeed;
@@ -278,6 +373,13 @@ public class WayPropertySet {
             return bestSpeed;
         else
             return this.defaultSpeed;
+    }
+
+    /**
+     * Returns the current car speed lookup hashmap. Used for testing only.
+     */
+    public HashMap<String, Float> getCarSpeedLookup() {
+        return carSpeedLookup;
     }
 
     public Set<T2<Alert, NoteMatcher>> getNoteForWay(OSMWithTags way) {

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestOpenStreetMapGraphBuilder.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestOpenStreetMapGraphBuilder.java
@@ -209,6 +209,7 @@ public class TestOpenStreetMapGraphBuilder extends TestCase {
         way.addTag("surface", "gravel");
 
         WayPropertySet wayPropertySet = new WayPropertySet();
+        wayPropertySet.index();
 
         // where there are no way specifiers, the default is used
         assertEquals(wayPropertySet.getDataForWay(way), wayPropertySet.defaultProperties);
@@ -230,6 +231,7 @@ public class TestOpenStreetMapGraphBuilder extends TestCase {
         footways_allow_peds.setPermission(StreetTraversalPermission.PEDESTRIAN);
 
         wayPropertySet.addProperties(footway_only, footways_allow_peds);
+        wayPropertySet.index();
 
         WayProperties dataForWay = wayPropertySet.getDataForWay(way);
         // the first one is found
@@ -245,6 +247,8 @@ public class TestOpenStreetMapGraphBuilder extends TestCase {
         safer_and_peds.setPermission(StreetTraversalPermission.PEDESTRIAN);
 
         wayPropertySet.addProperties(lane_and_footway, safer_and_peds);
+        wayPropertySet.index();
+
         dataForWay = wayPropertySet.getDataForWay(way);
         assertEquals(dataForWay, safer_and_peds);
 
@@ -253,6 +257,7 @@ public class TestOpenStreetMapGraphBuilder extends TestCase {
         WayProperties gravel_is_dangerous = new WayProperties();
         gravel_is_dangerous.setSafetyFeatures(new P2<Double>(2.0, 2.0));
         wayPropertySet.addProperties(gravel, gravel_is_dangerous, true);
+        wayPropertySet.index();
 
         dataForWay = wayPropertySet.getDataForWay(way);
         assertEquals(dataForWay.getSafetyFeatures().first, 1.5);
@@ -268,6 +273,8 @@ public class TestOpenStreetMapGraphBuilder extends TestCase {
         track_is_safest.setSafetyFeatures(new P2<Double>(0.25, 0.25));
 
         wayPropertySet.addProperties(track_only, track_is_safest);
+        wayPropertySet.index();
+
         dataForWay = wayPropertySet.getDataForWay(way);
         assertEquals(0.25, dataForWay.getSafetyFeatures().first); // right (with traffic) comes
                                                                        // from track

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestOpenStreetMapGraphBuilder.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestOpenStreetMapGraphBuilder.java
@@ -280,6 +280,12 @@ public class TestOpenStreetMapGraphBuilder extends TestCase {
                                                                        // from track
         assertEquals(0.75, dataForWay.getSafetyFeatures().second); // left comes from lane
 
+        // make sure the way property cache has been set with proper values along the way
+        dataForWay = wayPropertySet.getWayPropertyLookup().get("cycleway:right=track;cycleway=lane;highway=footway");
+        assertEquals(0.25, dataForWay.getSafetyFeatures().first); // right (with traffic) comes
+        // from track
+        assertEquals(0.75, dataForWay.getSafetyFeatures().second); // left comes from lane
+
         way = new OSMWay();
         way.addTag("highway", "footway");
         way.addTag("footway", "sidewalk");

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestWayPropertySet.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestWayPropertySet.java
@@ -5,6 +5,8 @@ import org.opentripplanner.openstreetmap.model.OSMWithTags;
 
 import junit.framework.TestCase;
 
+import java.util.HashMap;
+
 /**
  * Test the WayPropertySet 
  * @author mattwigway
@@ -49,6 +51,7 @@ public class TestWayPropertySet extends TestCase {
        WayPropertySet wps = new WayPropertySet();
        DefaultWayPropertySetSource source = new DefaultWayPropertySetSource();
        source.populateProperties(wps);
+       wps.index();
        
        OSMWithTags way;
        
@@ -83,6 +86,11 @@ public class TestWayPropertySet extends TestCase {
        way.addTag("maxspeed", "35 mph");
        assertTrue(within(kmhAsMs(35 * 1.609f), wps.getCarSpeedForWay(way, false), epsilon));
        assertTrue(within(kmhAsMs(35 * 1.609f), wps.getCarSpeedForWay(way, true), epsilon));
+
+       // make sure the car speed cache has been populated with some values along the way
+       HashMap<String, Float> carSpeedLookup = wps.getCarSpeedLookup();
+       assertTrue(within(kmhAsMs(20), carSpeedLookup.get("maxspeed:forward=80;maxspeed:reverse=20;maxspeed=40;back==true"), epsilon));
+       assertTrue(within(kmhAsMs(80), carSpeedLookup.get("maxspeed:forward=80;maxspeed:reverse=20;maxspeed=40;back==false"), epsilon));
        
        // test with no maxspeed tags
        wps = new WayPropertySet();
@@ -90,6 +98,7 @@ public class TestWayPropertySet extends TestCase {
        wps.addSpeedPicker(getSpeedPicker("highway=*", kmhAsMs(35)));
        wps.addSpeedPicker(getSpeedPicker("surface=gravel", kmhAsMs(10)));
        wps.defaultSpeed = kmhAsMs(25);
+       wps.index();
        
        way = new OSMWithTags();
      

--- a/src/test/java/org/opentripplanner/openstreetmap/model/OSMWayTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/model/OSMWayTest.java
@@ -278,6 +278,7 @@ public class OSMWayTest {
 
     private P2<StreetTraversalPermission> getWayProperties(OSMWay way) {
         WayPropertySet wayPropertySet = new WayPropertySet();
+        wayPropertySet.index();
         WayProperties wayData = wayPropertySet.getDataForWay(way);
 
         StreetTraversalPermission permissions = OSMFilter.getPermissionsForWay(way,


### PR DESCRIPTION
This PR reduces the calculation time of the OpenStreetMap graph builder module by memoizing certain values that were frequently recomputed. In particular, the calculation of the way data (which is used for calculating the StreetTravelPermissions and the bicycleSafetyFactor) and car speed had this optimization applied. 

Whenever the way data is calculated, OTP loops through all possible values (there are ~170 of them) in the DefaultWayPropertySetSource class and then figures out what the best match is for both directions of the way. A similar thing occurs when calculating the car speed. Although there aren't as many possible speed values, there is a regex that sometimes runs which could also slow things down a bit.

OTP would previously do these calculations of the way data and car speed for every way despite the high likelihood of ways throughout the network having the same exact set of applicable tags. This PR has code that compiles a list of applicable tags of a way and will then calculate the way data or car speed once and save it in a memorized cache so that whenever another way is analyzed that has the same set of applicable tags, it will also use this pre-calculated way data or speed.

Also, this PR includes adds a null check for micromobility restrictions to a certain method to avoid spending time getting street geometry which also reduces the amount of time for building the graph.