### PR TITLE
Refactor driving reluctance factors

### DIFF
--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -124,16 +124,26 @@ public abstract class RoutingResource {
     /**
      * An additive weight for how bad each meter of driving is, compared to being in transit for equal distances. It is
      * recommended to use this sparingly as larger values will incentivize driving paths that cut through neighborhoods.
-     * Ex: with a factor of 0.2, an edge that is ten meters in length would have 2 units of "weight" added to the overall
-     * weight of traversing the edge while driving.
+     *
+     * Defaults to -1.0 which indicates that driving reluctance should not be used in car routing requests. Empirically,
+     * a value of 0.2 seems work OK.
+     *
+     * Ex: with a factor of 0.2, an edge that is ten meters in length would have 2 units of "weight" added to the
+     * overall weight of traversing the edge while driving. OTP's weight units are roughly equivalent to seconds.
      */
     @QueryParam("driveDistanceReluctance")
     protected Double driveDistanceReluctance;
 
     /**
      * An additive weight for how bad each second of driving is, compared to being in transit for equal lengths of time.
+     *
+     * Defaults to -1.0 which indicates that driving reluctance should not be used in car routing requests. Empirically,
+     * a value of 5.0 seems to work well in disincentivizing driving to some park and rides that may seem too close to
+     * the destination.
+     *
      * Ex: with a factor of 1.75, an edge that takes ten seconds to traverse while driving would have 17.5 units of
-     * "weight" added to the overall weight of traversing the edge.
+     * "weight" added to the overall weight of traversing the edge. OTP's weight units are roughly equivalent to
+     * seconds.
      */
     @QueryParam("driveTimeReluctance")
     protected Double driveTimeReluctance;

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -121,6 +121,23 @@ public abstract class RoutingResource {
     @QueryParam("waitReluctance")
     protected Double waitReluctance;
 
+    /**
+     * An additive weight for how bad each meter of driving is, compared to being in transit for equal distances. It is
+     * recommended to use this sparingly as larger values will incentivize driving paths that cut through neighborhoods.
+     * Ex: with a factor of 0.2, an edge that is ten meters in length would have 2 units of "weight" added to the overall
+     * weight of traversing the edge while driving.
+     */
+    @QueryParam("driveDistanceReluctance")
+    protected Double driveDistanceReluctance;
+
+    /**
+     * An additive weight for how bad each second of driving is, compared to being in transit for equal lengths of time.
+     * Ex: with a factor of 1.75, an edge that takes ten seconds to traverse while driving would have 17.5 units of
+     * "weight" added to the overall weight of traversing the edge.
+     */
+    @QueryParam("driveTimeReluctance")
+    protected Double driveTimeReluctance;
+
     /** How much less bad is waiting at the beginning of the trip (replaces waitReluctance) */
     @QueryParam("waitAtBeginningFactor")
     protected Double waitAtBeginningFactor;
@@ -687,6 +704,13 @@ public abstract class RoutingResource {
             modes.applyToRoutingRequest(request);
             request.setModes(request.modes);
         }
+
+        // Apply a per-request drive distance or time reluctance factor.
+        if (driveDistanceReluctance != null)
+            request.driveDistanceReluctance = driveDistanceReluctance;
+
+        if (driveTimeReluctance != null)
+            request.driveTimeReluctance = driveTimeReluctance;
 
         if (request.allowBikeRental && bikeSpeed == null) {
             //slower bike speed for bike sharing, based on empirical evidence from DC.

--- a/src/main/java/org/opentripplanner/api/parameter/QualifiedMode.java
+++ b/src/main/java/org/opentripplanner/api/parameter/QualifiedMode.java
@@ -64,12 +64,8 @@ public class QualifiedMode implements Serializable {
                 req.onlyTransitTrips = true;
             } else if (this.qualifiers.contains(Qualifier.HAIL)) {
                 req.useTransportationNetworkCompany = true;
-                req.driveTimeReluctance = 1.75;
-                req.driveDistanceReluctance = 0.2;
             } else if (this.qualifiers.contains(Qualifier.RENT)) {
                 req.allowCarRental = true;
-                req.driveTimeReluctance = 1.75;
-                req.driveDistanceReluctance = 0.2;
             } else {
                 req.kissAndRide = true;
                 // require transit to be used in Kiss & Ride, otherwise it'd just be a "Kiss" query

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -635,7 +635,7 @@ public class RoutingRequest implements Cloneable, Serializable {
      * request might have different reluctance factors than a car rental request. Using the drive distance reluctance
      * factor should be used sparingly as it can incentivize cutting through low-traffic neighborhoods.
      * The time and distance reluctance factors add weight to a shortest path search in {@link StreetEdge#doTraverse}.
-     * These are set to -1 to indicate that driving reluctance should not be used in default car routing requests.
+     * These are set to -1 to indicate that driving reluctance should not be used in car routing requests.
      */
     public double driveTimeReluctance = -1.0;
     public double driveDistanceReluctance = -1.0;

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -629,11 +629,13 @@ public class RoutingRequest implements Cloneable, Serializable {
     public boolean useTransportationNetworkCompany;
 
     /*
-     * driving reluctances are used in TNC requests.
-     * It is set in org.opentripplanner.api.parameter.QualifiedMode.
-     * The driveTimeReluctance is used as a multiplier to add weight to a shortest path search in
-     *   org.opentripplanner.routing.edgetype.StreetEdge.
-     * It is set to -1 to indicate that driving reluctance should not be used in default car routing requests.
+     * Driving reluctances are used in car-only or multimodal requests with car + transit queries. These can be set in
+     * the router-config.json file or in an individual request. It is recommended to set these in individual routing
+     * requests to make sure requests with certain driving types use specific reluctance factors. For example, a P&R
+     * request might have different reluctance factors than a car rental request. Using the drive distance reluctance
+     * factor should be used sparingly as it can incentivize cutting through low-traffic neighborhoods.
+     * The time and distance reluctance factors add weight to a shortest path search in {@link StreetEdge#doTraverse}.
+     * These are set to -1 to indicate that driving reluctance should not be used in default car routing requests.
      */
     public double driveTimeReluctance = -1.0;
     public double driveDistanceReluctance = -1.0;


### PR DESCRIPTION
This refactors the application of driving reluctance factors in a number of ways.

Previously, the driving reluctance factors only applied to the CAR_HAIL and CAR_RENT modes. Furthermore, they were hard-coded and overrode any default configurations set in the `router-config.json` file.

This changes it so that these factors are not overwritten to hardcoded values and furthermore, makes it possible to change these factors on a per-request basis. This breaks some configuration as it will now be required to either modify the `router-config.json` file to include the defaults or change whatever program that is calling the OTP API to send in query parameters on a per-request basis.