### PR TITLE
Refactor trip banning to ban trip sequences

### DIFF
--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -908,9 +908,15 @@ public abstract class RoutingResource {
     }
 
     /**
-     * Take a string in the format agency:id or agency:id:1:2:3:4.
-     * TODO Improve Javadoc. What does this even mean? Why are there so many colons and numbers?
-     * Convert to a Map from trip --> set of int.
+     * Create a banned trips map.
+     *
+     * @param banned A string with a multi-part format.
+     *               The first part consists of TRIP_ID,TRIP_ID (multiple trip IDs separated by commas)
+     *               The TRIP_ID has various IDs separated by colons. There must be at least two colon-separated values,
+     *               otherwise the TRIP_ID is skipped. The first value indicates teh agency ID string. The second value
+     *               indicates the trip ID string within the context of the agency. Any further values must be integers
+     *               representing stop sequences within the trip that are banned. If only the agency ID and trip ID are
+     *               provided, the all stops within the trip will be banned.
      */
     private HashMap<FeedScopedId, BannedStopSet> makeBannedTripMap(String banned) {
         if (banned == null) {
@@ -918,9 +924,13 @@ public abstract class RoutingResource {
         }
 
         HashMap<FeedScopedId, BannedStopSet> bannedTripMap = new HashMap<FeedScopedId, BannedStopSet>();
+        // split multiple trip IDs into single trip IDs
         String[] tripStrings = banned.split(",");
         for (String tripString : tripStrings) {
-            // TODO this apparently allows banning stops within a trip with integers. Why?
+            // split tripId into parts as follows:
+            // - position 0: agency ID
+            // - position 1: trip ID
+            // - position 2+: an integer representing the stop index within the trip
             String[] parts = tripString.split(":");
             if (parts.length < 2) continue; // throw exception?
             String agencyIdString = parts[0];

--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -656,7 +656,8 @@ public abstract class GraphPathToTripPlanConverter {
             String alightRule = null;
 
             for (int j = 1; j < legsStates[i].length; j++) {
-                if (legsStates[i][j].getBackEdge() instanceof TimedTransferEdge) {
+                Edge backEdge = legsStates[i][j].getBackEdge();
+                if (backEdge instanceof TimedTransferEdge) {
                     // TimedTransferEdges bypass the street network (thus not resulting in the traversal of pathway
                     // edges) and are going to force a transfer (thus not interlining with a previous leg). Therefore,
                     // this loop can be exited safely since this information does not need to be collected. If this loop
@@ -665,8 +666,8 @@ public abstract class GraphPathToTripPlanConverter {
                     // least with the data inserted into the Leg instance representing the timed transfer)).
                     break;
                 }
-                if (legsStates[i][j].getBackEdge() instanceof PatternEdge) {
-                    PatternEdge patternEdge = (PatternEdge) legsStates[i][j].getBackEdge();
+                if (backEdge instanceof PatternEdge) {
+                    PatternEdge patternEdge = (PatternEdge) backEdge;
                     TripPattern tripPattern = patternEdge.getPattern();
 
                     Integer fromIndex = legs.get(i).from.stopIndex;
@@ -678,7 +679,7 @@ public abstract class GraphPathToTripPlanConverter {
                     boardRule = getBoardAlightMessage(boardType);
                     alightRule = getBoardAlightMessage(alightType);
                 }
-                if (legsStates[i][j].getBackEdge() instanceof PathwayEdge) {
+                if (backEdge instanceof PathwayEdge) {
                     legs.get(i).pathway = true;
                 }
             }

--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -42,6 +42,7 @@ import org.opentripplanner.routing.edgetype.RentABikeOffEdge;
 import org.opentripplanner.routing.edgetype.RentABikeOnEdge;
 import org.opentripplanner.routing.edgetype.SimpleTransfer;
 import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.edgetype.TimedTransferEdge;
 import org.opentripplanner.routing.edgetype.TransitBoardAlight;
 import org.opentripplanner.routing.edgetype.TripPattern;
 import org.opentripplanner.routing.error.TransportationNetworkCompanyAvailabilityException;
@@ -655,6 +656,15 @@ public abstract class GraphPathToTripPlanConverter {
             String alightRule = null;
 
             for (int j = 1; j < legsStates[i].length; j++) {
+                if (legsStates[i][j].getBackEdge() instanceof TimedTransferEdge) {
+                    // TimedTransferEdges bypass the street network (thus not resulting in the traversal of pathway
+                    // edges) and are going to force a transfer (thus not interlining with a previous leg). Therefore,
+                    // this loop can be exited safely since this information does not need to be collected. If this loop
+                    // isn't exited from in this case, an ArrayIndexOutOfBounds exception might occur resulting from a
+                    // mismatch of transit data in the leg state data info (which might be another bug in itself (at
+                    // least with the data inserted into the Leg instance representing the timed transfer)).
+                    break;
+                }
                 if (legsStates[i][j].getBackEdge() instanceof PatternEdge) {
                     PatternEdge patternEdge = (PatternEdge) legsStates[i][j].getBackEdge();
                     TripPattern tripPattern = patternEdge.getPattern();

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -1195,6 +1195,7 @@ public class RoutingRequest implements Cloneable, Serializable {
             RoutingRequest clone = (RoutingRequest) super.clone();
             clone.bannedRoutes = bannedRoutes.clone();
             clone.bannedTrips = (HashMap<FeedScopedId, BannedStopSet>) bannedTrips.clone();
+            clone.bannedTripSequences = new LinkedList<>(bannedTripSequences);
             clone.bannedStops = bannedStops.clone();
             clone.bannedStopsHard = bannedStopsHard.clone();
             clone.whiteListedAgencies = (HashSet<String>) whiteListedAgencies.clone();

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -1559,11 +1559,11 @@ public class RoutingRequest implements Cloneable, Serializable {
      * won't be used in the graph path finding if the sequence of trips is detected in any order in another path. See
      * {@link TripTimes#tripOrTripSequenceIsBanned(State, int)} for further details.
      */
-    public void banTripsInPath(GraphPath path) {
+    public void banTripSequencesInPath(GraphPath path) {
         List<FeedScopedId> tripIds = path.getTrips();
         List<FeedScopedId> callAndRideTripIds = path.getCallAndRideTrips();
         // ban a sequence of trips if none of the tripIds were call and ride trips
-        if (!tripIds.stream().anyMatch(tripId -> callAndRideTripIds.contains(tripId))) {
+        if (tripIds.stream().noneMatch(callAndRideTripIds::contains)) {
             bannedTripSequences.add(tripIds);
         }
     }

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -188,16 +188,11 @@ public class GraphPathFinder {
             for (GraphPath path : newPaths) {
                 // path.dump();
                 List<FeedScopedId> tripIds = path.getTrips();
-                List<FeedScopedId> callAndRideTripIds = path.getCallAndRideTrips();
-                for (FeedScopedId tripId : tripIds) {
-                    if (!callAndRideTripIds.contains(tripId)) {
-                        options.banTrip(tripId);
-                    }
-                }
-                if (tripIds.isEmpty()) {
+                if (path.getTrips().isEmpty()) {
                     // This path does not use transit (is entirely on-street). Do not repeatedly find the same one.
                     options.onlyTransitTrips = true;
                 }
+                options.banTripsInPath(path);
                 // Call-and-Ride trips should not use regular trip-banning, since call-and-ride trips can beused in
                 // multiple ways (e.g. from origin to destination, or from origin to a transfer stop.) Instead,
                 // after an itinerary which uses call-and-ride is found, reduce the allowable call-and-ride duration
@@ -306,9 +301,7 @@ public class GraphPathFinder {
                             (options.arriveBy && joinedPath.states.getLast().getTimeInMillis() < options.dateTime * 1000)){
                         joinedPaths.add(joinedPath);
                         if(newPaths.size() > 1){
-                            for (FeedScopedId tripId : joinedPath.getTrips()) {
-                                options.banTrip(tripId);
-                            }
+                            options.banTripsInPath(joinedPath);
                         }
                     }
                 }

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -184,15 +184,15 @@ public class GraphPathFinder {
                 newPaths = compactLegsByReversedSearch(aStar, originalReq, options, newPaths, timeout, reversedSearchHeuristic);
             }
 
-            // Find all trips used in this path and ban them for the remaining searches
+            // Find all trip sequences used in this path and ban them for the remaining searches
             for (GraphPath path : newPaths) {
                 // path.dump();
                 List<FeedScopedId> tripIds = path.getTrips();
-                if (path.getTrips().isEmpty()) {
+                if (tripIds.isEmpty()) {
                     // This path does not use transit (is entirely on-street). Do not repeatedly find the same one.
                     options.onlyTransitTrips = true;
                 }
-                options.banTripsInPath(path);
+                options.banTripSequencesInPath(path);
                 // Call-and-Ride trips should not use regular trip-banning, since call-and-ride trips can beused in
                 // multiple ways (e.g. from origin to destination, or from origin to a transfer stop.) Instead,
                 // after an itinerary which uses call-and-ride is found, reduce the allowable call-and-ride duration
@@ -301,7 +301,7 @@ public class GraphPathFinder {
                             (options.arriveBy && joinedPath.states.getLast().getTimeInMillis() < options.dateTime * 1000)){
                         joinedPaths.add(joinedPath);
                         if(newPaths.size() > 1){
-                            options.banTripsInPath(joinedPath);
+                            options.banTripSequencesInPath(joinedPath);
                         }
                     }
                 }

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -351,6 +351,7 @@ public class GraphPathFinder {
         reversedOptions.maxTransfers = 4;
         reversedOptions.longDistance = true;
         reversedOptions.bannedTrips = options.bannedTrips;
+        reversedOptions.bannedTripSequences = options.bannedTripSequences;
         return reversedOptions;
     }
 

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.trippattern;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collections;
@@ -494,8 +495,8 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
             return false;
         }
 
-        // compile list of trips seen so far in states
-        List<FeedScopedId> tripsInState = Arrays.asList(trip.getId());
+        // compile list of trips seen so far in states (use ArrayList constructor to ensure a mutable list is returned)
+        List<FeedScopedId> tripsInState = new ArrayList<>(Arrays.asList(trip.getId()));
         State tripFindingState = state0;
         Trip lastTrip = trip;
         while (tripFindingState != null) {
@@ -509,8 +510,8 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
             tripFindingState = tripFindingState.getBackState();
         }
 
-        // reverse trips if finding for arrive-by search
-        if (options.arriveBy) {
+        // reverse trips if finding for depart-at search to make sure the list is in chronological order
+        if (!options.arriveBy) {
             Collections.reverse(tripsInState);
         }
 

--- a/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
+++ b/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -23,8 +22,8 @@ import org.opentripplanner.routing.core.ServiceDay;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.routing.edgetype.PatternHop;
 import org.opentripplanner.routing.edgetype.PatternInterlineDwell;
-import org.opentripplanner.routing.edgetype.TablePatternEdge;
 import org.opentripplanner.routing.edgetype.TransitBoardAlight;
 import org.opentripplanner.routing.edgetype.TripPattern;
 import org.opentripplanner.routing.graph.Graph;
@@ -33,8 +32,8 @@ import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.request.BannedStopSet;
 import org.opentripplanner.routing.vertextype.PatternArriveVertex;
 import org.opentripplanner.routing.vertextype.PatternDepartVertex;
-import org.opentripplanner.routing.vertextype.PatternStopVertex;
 import org.opentripplanner.routing.vertextype.TransitStop;
+import org.opentripplanner.routing.vertextype.TransitStopArrive;
 import org.opentripplanner.routing.vertextype.TransitStopDepart;
 
 import static org.mockito.Mockito.*;
@@ -100,10 +99,17 @@ public class TripTimesTest {
         assertFalse(s.tripAcceptable(s0, 0));
     }
 
+    /**
+     * Some tests for checking if a trip sequence should be banned. A lot of the state creation in here lacks full data
+     * representation and instead contains the minimum amount of data needed to test the
+     * {@link TripTimes#tripOrTripSequenceIsBanned(State, int)} method.
+     */
     @Test
     public void testTripOrTripSequenceIsBanned() {
         Graph graph = new Graph();
         String agencyId = "mock agency";
+
+        // make some generic trips for testing
         Trip tripA = new Trip();
         FeedScopedId tripAId = new FeedScopedId(agencyId, "A");
         tripA.setId(tripAId);
@@ -115,55 +121,127 @@ public class TripTimesTest {
         tripC.setId(tripCId);
         Route route = new Route();
         tripA.setRoute(route);
-        List<StopTime> stopTimes = Arrays.asList(new StopTime(), new StopTime());
-        TripTimes s = new TripTimes(tripA, stopTimes, new Deduplicator());
-        Vertex v = new SimpleConcreteVertex(graph, "", 0.0, 0.0);
+
+        // stop A
         Stop stopA = new Stop();
         FeedScopedId stopAId = new FeedScopedId(agencyId, "A");
         stopA.setId(stopAId);
         StopTime stopTime1 = new StopTime();
         stopTime1.setStop(stopA);
         TransitStop transitStopA = new TransitStop(graph, stopA);
-        TransitStopDepart departingStop = new TransitStopDepart(graph, stopA, transitStopA);
-        TripPattern tripPattern1 = new TripPattern(route, new StopPattern(Arrays.asList(stopTime1)));
-        tripPattern1.arriveVertices[0] = new PatternArriveVertex(graph, tripPattern1, 0);
-        TripPattern tripPattern2 = new TripPattern(route, new StopPattern(Arrays.asList(stopTime1)));
-        tripPattern2.departVertices[0] = new PatternDepartVertex(graph, tripPattern1, 0);
+        TransitStopDepart departingStopA = new TransitStopDepart(graph, stopA, transitStopA);
+        TransitStopArrive arrivingStopA = new TransitStopArrive(graph, stopA, transitStopA);
 
+        // stop B
+        Stop stopB = new Stop();
+        FeedScopedId stopBId = new FeedScopedId(agencyId, "B");
+        stopA.setId(stopBId);
+        StopTime stopTime2 = new StopTime();
+        stopTime2.setStop(stopB);
+
+        // pattern 1
+        TripPattern tripPattern1 = new TripPattern(route, new StopPattern(Arrays.asList(stopTime1, stopTime2)));
+        PatternDepartVertex patternDepartVertex1 = new PatternDepartVertex(graph, tripPattern1, 0);
+        tripPattern1.departVertices[0] = patternDepartVertex1;
+        PatternArriveVertex patternArriveVertex1 = new PatternArriveVertex(graph, tripPattern1, 0);
+        tripPattern1.arriveVertices[1] = patternArriveVertex1;
+
+        // pattern 2
+        TripPattern tripPattern2 = new TripPattern(route, new StopPattern(Arrays.asList(stopTime1, stopTime2)));
+        PatternDepartVertex patternDepartVertex2 = new PatternDepartVertex(graph, tripPattern2, 0);
+        tripPattern2.departVertices[0] = patternDepartVertex2;
+
+        // initialize request and first state as starting a departure from a transit stop
         RoutingRequest request = new RoutingRequest(TraverseMode.WALK);
-        request.setRoutingContext(graph, departingStop, v);
+        Vertex v = new SimpleConcreteVertex(graph, "", 0.0, 0.0);
+        request.setRoutingContext(graph, departingStopA, v);
         State s0 = new State(request);
-        StateEditor s1e = s0.edit(new TransitBoardAlight(
-            departingStop,
-            new PatternStopVertex(graph, "board tripA at stopA", tripPattern1, stopA),
-            0,
-            TraverseMode.BUS
-        ));
-        s1e.setTripTimes(new TripTimes(tripA, Arrays.asList(stopTime1), new Deduplicator()));
-        State s1 = s1e.makeState();
+
+        // make a generic StopTimes instance for testing
+        List<StopTime> stopTimes = Arrays.asList(new StopTime(), new StopTime());
 
         // trip should not be banned if there aren't any banned trips or trip sequences
-        assertFalse(s.tripOrTripSequenceIsBanned(s1, 0));
+        TripTimes tripTimesForTripA = new TripTimes(tripA, stopTimes, new Deduplicator());
+        assertFalse(tripTimesForTripA.tripOrTripSequenceIsBanned(s0, 0));
 
         // trip should be banned if exactly one of the trips is banned
         request.bannedTrips.put(tripAId, BannedStopSet.ALL);
-        assertTrue(s.tripOrTripSequenceIsBanned(s1, 0));
+        assertTrue(tripTimesForTripA.tripOrTripSequenceIsBanned(s0, 0));
 
-        // trip should not be banned if only part of a banned sequence exists
+        // trip should not be banned if only part of a banned sequence would exist
         request.bannedTrips.clear();
         request.bannedTripSequences.add(Arrays.asList(tripAId, tripBId));
-        assertFalse(s.tripOrTripSequenceIsBanned(s1, 0));
+        assertFalse(tripTimesForTripA.tripOrTripSequenceIsBanned(s0, 0));
 
-        // trip should not be banned for sequence with additional trip
-        // TODO make the following tests
-//        StateEditor s2e = s1.edit(new PatternInterlineDwell(tripPattern1, tripPattern2));
-//        s2e.setTripTimes(new TripTimes(tripC, Arrays.asList(stopTime1), new Deduplicator()));
-//        State s2 = s2e.makeState();
-//        assertFalse(s.tripOrTripSequenceIsBanned(s2, 0));
+        // board a pattern
+        StateEditor s1e = s0.edit(new TransitBoardAlight(
+            departingStopA,
+            patternDepartVertex1,
+            0,
+            TraverseMode.BUS
+        ));
+        // trip sequence after this is now just [tripA]
+        s1e.setTripTimes(new TripTimes(tripA, Arrays.asList(stopTime1), new Deduplicator()));
+        State s1 = s1e.makeState();
+
+        // trip should not be banned for sequence with additional trip not in banned sequence
+        TripTimes tripTimesForTripC = new TripTimes(tripC, stopTimes, new Deduplicator());
+        assertFalse(tripTimesForTripC.tripOrTripSequenceIsBanned(s1, 0));
 
         // trip should be banned if exact banned trip sequence occurs
+        TripTimes tripTimesForTripB = new TripTimes(tripB, stopTimes, new Deduplicator());
+        assertTrue(tripTimesForTripB.tripOrTripSequenceIsBanned(s1, 0));
 
         // trip should be banned in non-continuous sequence
+        // add to state, first add a pattern hop
+        StateEditor s2e = s1.edit(new PatternHop(patternDepartVertex1, patternArriveVertex1, stopA, stopB, 0));
+        State s2 = s2e.makeState();
+        // at this stop, the route changes to another route with tripC (as indicated by the PatternInterlineDwell edge)
+        StateEditor s3e = s2.edit(new PatternInterlineDwell(tripPattern1, tripPattern2));
+        // trip sequence after this is now [tripA -> tripC]
+        s3e.setTripTimes(new TripTimes(tripC, Arrays.asList(stopTime1), new Deduplicator()));
+        State s3 = s3e.makeState();
+        assertTrue(tripTimesForTripB.tripOrTripSequenceIsBanned(s3, 0));
+
+        // arriveBy tests
+        // initialize new arriveByRequest
+        RoutingRequest arriveByRequest = new RoutingRequest(TraverseMode.WALK);
+        arriveByRequest.setRoutingContext(graph, arrivingStopA, v);
+        arriveByRequest.setArriveBy(true);
+        State as0 = new State(arriveByRequest);
+        arriveByRequest.bannedTripSequences.add(Arrays.asList(tripAId, tripBId));
+
+        // trip should not be banned if only part of a banned sequence would exist
+        arriveByRequest.bannedTripSequences.add(Arrays.asList(tripAId, tripBId));
+        assertFalse(tripTimesForTripB.tripOrTripSequenceIsBanned(as0, 0));
+
+        // alight a pattern
+        StateEditor as1e = as0.edit(new TransitBoardAlight(
+            patternArriveVertex1,
+            arrivingStopA,
+            0,
+            TraverseMode.BUS
+        ));
+        // trip sequence after this is now just [tripB]
+        as1e.setTripTimes(new TripTimes(tripB, Arrays.asList(stopTime1), new Deduplicator()));
+        State as1 = as1e.makeState();
+
+        // trip should not be banned for sequence with additional trip not in banned sequence
+        assertFalse(tripTimesForTripC.tripOrTripSequenceIsBanned(as1, 0));
+
+        // trip should be banned if exact banned trip sequence occurs
+        assertTrue(tripTimesForTripA.tripOrTripSequenceIsBanned(as1, 0));
+
+        // trip should be banned in non-continuous sequence
+        // first add a pattern hop
+        StateEditor as2e = as1.edit(new PatternHop(patternDepartVertex2, patternArriveVertex1, stopA, stopB, 0));
+        State as2 = as2e.makeState();
+        // at this stop, the route changes to another route with tripB (as indicated by the PatternInterlineDwell edge)
+        StateEditor as3e = as2.edit(new PatternInterlineDwell(tripPattern1, tripPattern2));
+        // trip sequence after this is now [tripC -> tripB]
+        as3e.setTripTimes(new TripTimes(tripC, Arrays.asList(stopTime1), new Deduplicator()));
+        State as3 = as3e.makeState();
+        assertTrue(tripTimesForTripA.tripOrTripSequenceIsBanned(as3, 0));
     }
 
     @Test


### PR DESCRIPTION
This adds functionality to ban sequences of trip IDs when searching for additional next-most-optimal itineraries. To illustrate what this now allows, see the below table:

|Most Optimal Trip Sequence|Potential new trip sequence in next-most-optimal sequence|ibi-dev|this PR|
|--|--|--|--|
| A | A | ❌ | ❌ |
| A > B | A > C | ❌ | ✅ |
| A > B | C > B | ❌ | ✅ |
| A > B | A > C > B | ❌ | ❌ |
| A > B > C | A > B > D | ❌ | ✅ |

**2021-04-12 Update:**

This PR now also includes a bugfix for a bug that occurs in certain situations with timed transfers. The bug was identified in https://github.com/ibi-group/OpenTripPlanner/pull/52#issuecomment-811448612 and is unrelated to the other code that was used to implement trip sequence banning.