### PR TITLE
Vehicle rental error handling

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -773,7 +773,8 @@ Steps to add a GBFS feed to a router:
      "type": "bike-rental",
      "frequencySec": 60,
      "sourceType": "gbfs",
-     "url": "http://coast.socialbicycles.com/opendata/"
+     "url": "http://coast.socialbicycles.com/opendata/",
+     "timeToLiveMinutes": 5
 }
 ```
 
@@ -783,7 +784,8 @@ Steps to add a GBFS feed to a router:
 type: "bike-rental"
 frequencySec: frequency in seconds in which the GBFS service will be polled
 sourceType: "gbfs"
-url: the URL of the GBFS feed (do not include the gbfs.json at the end) *
+url: the URL of the GBFS feed (do not include the gbfs.json at the end)
+timeToLiveMinutes: the amount of minutes to consider a reported vehicle to be active
 ```
 \* For a list of known GBFS feeds see the [list of known GBFS feeds](https://github.com/NABSA/gbfs/blob/master/systems.csv)
 
@@ -852,7 +854,8 @@ Add one entry in the `updater` field of `router-config.json` in the format:
     "sourceType": "car2go",
     "frequencySec": 60,
     "vehiclesUrl": "http://example.com/vehicles.json",
-    "regionsUrl": "http://example.com/regions.json"
+    "regionsUrl": "http://example.com/regions.json",
+    "timeToLiveMinutes": 5
 }
 ```
 
@@ -873,7 +876,8 @@ Add one entry in the `updater` field of `router-config.json` in the format:
     "network": "LIME",
     "sourceType": "gbfs",
     "url": "https://example.com/gbfs.json",
-    "regionsUrl": "file:/home/workspace/boundary.json"
+    "regionsUrl": "file:/home/workspace/boundary.json",
+    "timeToLiveMinutes": 5
 }
 ```
 

--- a/src/main/java/org/opentripplanner/api/model/RentalInfo.java
+++ b/src/main/java/org/opentripplanner/api/model/RentalInfo.java
@@ -15,7 +15,7 @@ public class RentalInfo {
     public final List<RentalUpdaterError> errors;
 
     /**
-     * The system information about the vehicle rental company. This is take directly from the company's GBFS system
+     * The system information about the vehicle rental company. This is taken directly from the company's GBFS system
      * information data if it is available.
      */
     public final SystemInformation.SystemInformationData systemInformationData;

--- a/src/main/java/org/opentripplanner/api/model/RentalInfo.java
+++ b/src/main/java/org/opentripplanner/api/model/RentalInfo.java
@@ -1,0 +1,29 @@
+package org.opentripplanner.api.model;
+
+import org.opentripplanner.updater.RentalUpdaterError;
+import org.opentripplanner.updater.vehicle_rental.GBFSMappings.SystemInformation;
+
+import java.util.List;
+
+/**
+ * Information about a particular vehicle rental company
+ */
+public class RentalInfo {
+    /**
+     * A list of errors encountered while fetching and parsing the vehicle rental feed.
+     */
+    public final List<RentalUpdaterError> errors;
+
+    /**
+     * The system information about the vehicle rental company. This is take directly from the company's GBFS system
+     * information data if it is available.
+     */
+    public final SystemInformation.SystemInformationData systemInformationData;
+
+    public RentalInfo(
+        List<RentalUpdaterError> errors, SystemInformation.SystemInformationData systemInformationData
+    ) {
+        this.errors = errors;
+        this.systemInformationData = systemInformationData;
+    }
+}

--- a/src/main/java/org/opentripplanner/api/model/TripPlan.java
+++ b/src/main/java/org/opentripplanner/api/model/TripPlan.java
@@ -26,8 +26,20 @@ public class TripPlan {
     public List<Itinerary> itinerary = new ArrayList<Itinerary>();
 
     /**
-     * Rental information about the networks used in the itinerary if applicable. This will be a map where keys are
-     * network names and the values are the information associated with that particular network.
+     * Rental information about the bike rental networks used in the itinerary if applicable. This will be a map
+     * where keys are network names and the values are the information associated with that particular network.
+     */
+    public Map<String, RentalInfo> bikeRentalInfo = null;
+
+    /**
+     * Rental information about the car rental networks used in the itinerary if applicable. This will be a map
+     * where keys are network names and the values are the information associated with that particular network.
+     */
+    public Map<String, RentalInfo> carRentalInfo = null;
+
+    /**
+     * Rental information about the vehicle rental networks used in the itinerary if applicable. This will be a map
+     * where keys are network names and the values are the information associated with that particular network.
      */
     public Map<String, RentalInfo> vehicleRentalInfo = null;
 

--- a/src/main/java/org/opentripplanner/api/model/TripPlan.java
+++ b/src/main/java/org/opentripplanner/api/model/TripPlan.java
@@ -3,7 +3,6 @@ package org.opentripplanner.api.model;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -24,24 +23,6 @@ public class TripPlan {
     /** A list of possible itineraries */
     @JsonProperty(value="itineraries")
     public List<Itinerary> itinerary = new ArrayList<Itinerary>();
-
-    /**
-     * Rental information about the bike rental networks used in the itinerary if applicable. This will be a map
-     * where keys are network names and the values are the information associated with that particular network.
-     */
-    public Map<String, RentalInfo> bikeRentalInfo = null;
-
-    /**
-     * Rental information about the car rental networks used in the itinerary if applicable. This will be a map
-     * where keys are network names and the values are the information associated with that particular network.
-     */
-    public Map<String, RentalInfo> carRentalInfo = null;
-
-    /**
-     * Rental information about the vehicle rental networks used in the itinerary if applicable. This will be a map
-     * where keys are network names and the values are the information associated with that particular network.
-     */
-    public Map<String, RentalInfo> vehicleRentalInfo = null;
 
     public TripPlan() { }
 

--- a/src/main/java/org/opentripplanner/api/model/TripPlan.java
+++ b/src/main/java/org/opentripplanner/api/model/TripPlan.java
@@ -3,6 +3,7 @@ package org.opentripplanner.api.model;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -23,6 +24,12 @@ public class TripPlan {
     /** A list of possible itineraries */
     @JsonProperty(value="itineraries")
     public List<Itinerary> itinerary = new ArrayList<Itinerary>();
+
+    /**
+     * Rental information about the networks used in the itinerary if applicable. This will be a map where keys are
+     * network names and the values are the information associated with that particular network.
+     */
+    public Map<String, RentalInfo> vehicleRentalInfo = null;
 
     public TripPlan() { }
 

--- a/src/main/java/org/opentripplanner/api/resource/BikeRental.java
+++ b/src/main/java/org/opentripplanner/api/resource/BikeRental.java
@@ -61,6 +61,8 @@ public class BikeRental {
         }
         BikeRentalStationList brsl = new BikeRentalStationList();
         brsl.stations = out;
+        brsl.errorsByNetwork = bikeRentalService.getErrorsByNetwork();
+        brsl.systemInformationDataByNetwork = bikeRentalService.getSystemInformationDataByNetwork();
         return brsl;
     }
 

--- a/src/main/java/org/opentripplanner/api/resource/BikeRentalStationList.java
+++ b/src/main/java/org/opentripplanner/api/resource/BikeRentalStationList.java
@@ -2,9 +2,16 @@ package org.opentripplanner.api.resource;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
+import org.opentripplanner.updater.RentalUpdaterError;
+import org.opentripplanner.updater.vehicle_rental.GBFSMappings.SystemInformation;
 
 public class BikeRentalStationList {
     public List<BikeRentalStation> stations = new ArrayList<BikeRentalStation>();
+
+    public Map<String, List<RentalUpdaterError>> errorsByNetwork;
+
+    public Map<String, SystemInformation.SystemInformationData> systemInformationDataByNetwork;
 }

--- a/src/main/java/org/opentripplanner/api/resource/CarRental.java
+++ b/src/main/java/org/opentripplanner/api/resource/CarRental.java
@@ -28,8 +28,8 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.xml.bind.annotation.XmlRootElement;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 
@@ -63,7 +63,7 @@ public class CarRental {
             envelope = new Envelope(-180,180,-90,90); 
         }
         Collection<CarRentalStation> stations = carRentalService.getCarRentalStations();
-        List<CarRentalStation> out = new ArrayList<>();
+        List<CarRentalStation> out = new LinkedList<>();
         for (CarRentalStation station : stations) {
             if (envelope.contains(station.x, station.y) &&
                 (station.x != 0 && station.y != 0) &&
@@ -77,6 +77,8 @@ public class CarRental {
         }
         CarRentalStationList carRentalStationList = new CarRentalStationList();
         carRentalStationList.stations = out;
+        carRentalStationList.errorsByNetwork = carRentalService.getErrorsByNetwork();
+        carRentalStationList.systemInformationDataByNetwork = carRentalService.getSystemInformationDataByNetwork();
         return carRentalStationList;
     }
 

--- a/src/main/java/org/opentripplanner/api/resource/CarRentalStationList.java
+++ b/src/main/java/org/opentripplanner/api/resource/CarRentalStationList.java
@@ -14,15 +14,17 @@
 package org.opentripplanner.api.resource;
 
 import org.opentripplanner.routing.car_rental.CarRentalStation;
+import org.opentripplanner.updater.RentalUpdaterError;
+import org.opentripplanner.updater.vehicle_rental.GBFSMappings.SystemInformation;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
-@XmlRootElement(name="CarRentalStationList")
 public class CarRentalStationList {
-    @XmlElements(value = { @XmlElement(name="station") })
     public List<CarRentalStation> stations = new ArrayList<CarRentalStation>();
+
+    public Map<String, List<RentalUpdaterError>> errorsByNetwork;
+
+    public Map<String, SystemInformation.SystemInformationData> systemInformationDataByNetwork;
 }

--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -188,7 +188,6 @@ public abstract class GraphPathToTripPlanConverter {
                 Leg lastLeg = i.legs.get(i.legs.size() - 1);
                 lastLeg.to.orig = plan.to.orig;
             }
-            addRentalInfo(plan, paths);
         }
         request.rctx.debugOutput.finishedRendering();
         return plan;
@@ -759,52 +758,6 @@ public abstract class GraphPathToTripPlanConverter {
                 }
             }
         }
-    }
-
-    /**
-     * Adds overall information about all rental systems that might have been available for this particular request.
-     */
-    private static void addRentalInfo(TripPlan plan, List<GraphPath> paths) {
-        RoutingRequest options = paths.get(0).states.get(0).getOptions();
-        Graph graph = options.rctx.graph;
-        BikeRentalStationService bikeRentalStationService = graph.getService(BikeRentalStationService.class);
-        CarRentalStationService carRentalStationService = graph.getService(CarRentalStationService.class);
-        VehicleRentalStationService vehicleRentalStationService = graph.getService(VehicleRentalStationService.class);
-
-        if (bikeRentalStationService != null && options.allowBikeRental) {
-            plan.bikeRentalInfo = makeRentalInfo(
-                bikeRentalStationService.getErrorsByNetwork(),
-                bikeRentalStationService.getSystemInformationDataByNetwork()
-            );
-        }
-
-        if (carRentalStationService != null && options.allowCarRental) {
-            plan.carRentalInfo = makeRentalInfo(
-                carRentalStationService.getErrorsByNetwork(),
-                carRentalStationService.getSystemInformationDataByNetwork()
-            );
-        }
-
-        if (vehicleRentalStationService != null && options.allowVehicleRental) {
-            plan.vehicleRentalInfo = makeRentalInfo(
-                vehicleRentalStationService.getErrorsByNetwork(),
-                vehicleRentalStationService.getSystemInformationDataByNetwork()
-            );
-        }
-    }
-
-    private static Map<String, RentalInfo> makeRentalInfo(
-        Map<String, List<RentalUpdaterError>> errorsByNetwork,
-        Map<String, SystemInformation.SystemInformationData> systemInformationDataByNetwork
-    ) {
-        Map<String, RentalInfo> rentalInfo = new HashMap<>();
-        for (String network : errorsByNetwork.keySet()) {
-            rentalInfo.put(
-                network,
-                new RentalInfo(errorsByNetwork.get(network), systemInformationDataByNetwork.get(network))
-            );
-        }
-        return rentalInfo;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -79,7 +79,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;

--- a/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
+++ b/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
@@ -63,6 +63,7 @@ public class PlannerResource extends RoutingResource {
             /* Fill in request fields from query parameters via shared superclass method, catching any errors. */
             request = super.buildRequest();
             router = otpServer.getRouter(request.routerId);
+            response.setRentalInfo(request, router);
 
             /* Find some good GraphPaths through the OTP Graph. */
             GraphPathFinder gpFinder = new GraphPathFinder(router); // we could also get a persistent router-scoped GraphPathFinder but there's no setup cost here

--- a/src/main/java/org/opentripplanner/api/resource/Response.java
+++ b/src/main/java/org/opentripplanner/api/resource/Response.java
@@ -2,12 +2,22 @@ package org.opentripplanner.api.resource;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.ws.rs.core.UriInfo;
 
+import org.opentripplanner.api.model.RentalInfo;
 import org.opentripplanner.api.model.TripPlan;
 import org.opentripplanner.api.model.error.PlannerError;
+import org.opentripplanner.routing.bike_rental.BikeRentalStationService;
+import org.opentripplanner.routing.car_rental.CarRentalStationService;
+import org.opentripplanner.routing.core.RoutingRequest;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
+import org.opentripplanner.standalone.Router;
+import org.opentripplanner.updater.RentalUpdaterError;
+import org.opentripplanner.updater.vehicle_rental.GBFSMappings.SystemInformation;
 
 /** Represents a trip planner response, will be serialized into XML or JSON by Jersey */
 public class Response {
@@ -21,6 +31,24 @@ public class Response {
     public DebugOutput debugOutput = null;
 
     public ElevationMetadata elevationMetadata = null;
+
+    /**
+     * Rental information about the bike rental networks used in the itinerary if applicable. This will be a map
+     * where keys are network names and the values are the information associated with that particular network.
+     */
+    public Map<String, RentalInfo> bikeRentalInfo = null;
+
+    /**
+     * Rental information about the car rental networks used in the itinerary if applicable. This will be a map
+     * where keys are network names and the values are the information associated with that particular network.
+     */
+    public Map<String, RentalInfo> carRentalInfo = null;
+
+    /**
+     * Rental information about the vehicle rental networks used in the itinerary if applicable. This will be a map
+     * where keys are network names and the values are the information associated with that particular network.
+     */
+    public Map<String, RentalInfo> vehicleRentalInfo = null;
 
     /** This no-arg constructor exists to make JAX-RS happy. */ 
     @SuppressWarnings("unused")
@@ -60,5 +88,49 @@ public class Response {
     public void setError(PlannerError error) {
         this.error = error;
     }
-    
+
+    /**
+     * Adds overall information about all rental systems that might have been available for this particular request.
+     */
+    public void setRentalInfo(RoutingRequest request, Router router) {
+        Graph graph = router.graph;
+        BikeRentalStationService bikeRentalStationService = graph.getService(BikeRentalStationService.class);
+        CarRentalStationService carRentalStationService = graph.getService(CarRentalStationService.class);
+        VehicleRentalStationService vehicleRentalStationService = graph.getService(VehicleRentalStationService.class);
+
+        if (bikeRentalStationService != null && request.allowBikeRental) {
+            bikeRentalInfo = makeRentalInfo(
+                bikeRentalStationService.getErrorsByNetwork(),
+                bikeRentalStationService.getSystemInformationDataByNetwork()
+            );
+        }
+
+        if (carRentalStationService != null && request.allowCarRental) {
+            carRentalInfo = makeRentalInfo(
+                carRentalStationService.getErrorsByNetwork(),
+                carRentalStationService.getSystemInformationDataByNetwork()
+            );
+        }
+
+        if (vehicleRentalStationService != null && request.allowVehicleRental) {
+            vehicleRentalInfo = makeRentalInfo(
+                vehicleRentalStationService.getErrorsByNetwork(),
+                vehicleRentalStationService.getSystemInformationDataByNetwork()
+            );
+        }
+    }
+
+    private static Map<String, RentalInfo> makeRentalInfo(
+        Map<String, List<RentalUpdaterError>> errorsByNetwork,
+        Map<String, SystemInformation.SystemInformationData> systemInformationDataByNetwork
+    ) {
+        Map<String, RentalInfo> rentalInfo = new HashMap<>();
+        for (String network : errorsByNetwork.keySet()) {
+            rentalInfo.put(
+                network,
+                new RentalInfo(errorsByNetwork.get(network), systemInformationDataByNetwork.get(network))
+            );
+        }
+        return rentalInfo;
+    }
 }

--- a/src/main/java/org/opentripplanner/api/resource/VehicleRental.java
+++ b/src/main/java/org/opentripplanner/api/resource/VehicleRental.java
@@ -28,7 +28,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.xml.bind.annotation.XmlRootElement;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/org/opentripplanner/api/resource/VehicleRental.java
+++ b/src/main/java/org/opentripplanner/api/resource/VehicleRental.java
@@ -30,6 +30,7 @@ import javax.ws.rs.core.MediaType;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 
@@ -68,7 +69,7 @@ public class VehicleRental {
             envelope = new Envelope(-180,180,-90,90); 
         }
         Collection<VehicleRentalStation> stations = vehicleRentalService.getVehicleRentalStations();
-        List<VehicleRentalStation> out = new ArrayList<>();
+        List<VehicleRentalStation> out = new LinkedList<>();
         for (VehicleRentalStation station : stations) {
             if (envelope.contains(station.x, station.y) &&
                 (station.x != 0 && station.y != 0) &&
@@ -82,6 +83,9 @@ public class VehicleRental {
         }
         VehicleRentalStationList vehicleRentalStationList = new VehicleRentalStationList();
         vehicleRentalStationList.stations = out;
+        vehicleRentalStationList.errorsByNetwork = vehicleRentalService.getErrorsByNetwork();
+        vehicleRentalStationList.systemInformationDataByNetwork =
+            vehicleRentalService.getSystemInformationDataByNetwork();
         return vehicleRentalStationList;
     }
 

--- a/src/main/java/org/opentripplanner/api/resource/VehicleRentalStationList.java
+++ b/src/main/java/org/opentripplanner/api/resource/VehicleRentalStationList.java
@@ -14,15 +14,17 @@
 package org.opentripplanner.api.resource;
 
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStation;
+import org.opentripplanner.updater.RentalUpdaterError;
+import org.opentripplanner.updater.vehicle_rental.GBFSMappings.SystemInformation;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
-@XmlRootElement(name="VehicleRentalStationList")
 public class VehicleRentalStationList {
-    @XmlElements(value = { @XmlElement(name="station") })
     public List<VehicleRentalStation> stations = new ArrayList<VehicleRentalStation>();
+
+    public Map<String, List<RentalUpdaterError>> errorsByNetwork;
+
+    public Map<String, SystemInformation.SystemInformationData> systemInformationDataByNetwork;
 }

--- a/src/main/java/org/opentripplanner/routing/bike_rental/BikeRentalStationService.java
+++ b/src/main/java/org/opentripplanner/routing/bike_rental/BikeRentalStationService.java
@@ -2,10 +2,15 @@ package org.opentripplanner.routing.bike_rental;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.opentripplanner.routing.bike_park.BikePark;
+import org.opentripplanner.updater.RentalUpdaterError;
+import org.opentripplanner.updater.vehicle_rental.GBFSMappings.SystemInformation;
 
 public class BikeRentalStationService implements Serializable {
     private static final long serialVersionUID = -1288992939159246764L;
@@ -13,6 +18,12 @@ public class BikeRentalStationService implements Serializable {
     private Set<BikeRentalStation> bikeRentalStations = new HashSet<>();
 
     private Set<BikePark> bikeParks = new HashSet<>();
+
+    /* A map of bike network name to the latest errors encountered while fetching the feed */
+    private Map<String, List<RentalUpdaterError>> errorsByNetwork = new HashMap<>();
+
+    /* A map of bike network name to the latest system information data received while fetching the feed */
+    private Map<String, SystemInformation.SystemInformationData> systemInformationDataByNetwork = new HashMap<>();
 
     public Collection<BikeRentalStation> getBikeRentalStations() {
         return bikeRentalStations;
@@ -40,5 +51,24 @@ public class BikeRentalStationService implements Serializable {
 
     public void removeBikePark(BikePark bikePark) {
         bikeParks.remove(bikePark);
+    }
+
+    public Map<String, List<RentalUpdaterError>> getErrorsByNetwork() {
+        return errorsByNetwork;
+    }
+
+    public void setErrorsForNetwork(String network, List<RentalUpdaterError> errors) {
+        errorsByNetwork.put(network, errors);
+    }
+
+    public Map<String, SystemInformation.SystemInformationData> getSystemInformationDataByNetwork() {
+        return systemInformationDataByNetwork;
+    }
+
+    public void setSystemInformationDataForNetwork(
+        String network,
+        SystemInformation.SystemInformationData systemInformationData
+    ) {
+        systemInformationDataByNetwork.put(network, systemInformationData);
     }
 }

--- a/src/main/java/org/opentripplanner/routing/car_rental/CarRentalStationService.java
+++ b/src/main/java/org/opentripplanner/routing/car_rental/CarRentalStationService.java
@@ -13,10 +13,14 @@
 
 package org.opentripplanner.routing.car_rental;
 
+import org.opentripplanner.updater.RentalUpdaterError;
+import org.opentripplanner.updater.vehicle_rental.GBFSMappings.SystemInformation;
+
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -27,6 +31,12 @@ public class CarRentalStationService implements Serializable {
     private Map<String, CarRentalRegion> carRentalRegions = new HashMap<>();
 
     private Set<CarRentalStation> carRentalStations = new HashSet<CarRentalStation>();
+
+    /* A map of car network name to the latest errors encountered while fetching the feed */
+    private Map<String, List<RentalUpdaterError>> errorsByNetwork = new HashMap<>();
+
+    /* A map of car network name to the latest system information data received while fetching the feed */
+    private Map<String, SystemInformation.SystemInformationData> systemInformationDataByNetwork = new HashMap<>();
 
     public Collection<CarRentalStation> getCarRentalStations() {
         return carRentalStations;
@@ -48,5 +58,24 @@ public class CarRentalStationService implements Serializable {
     
     public void addCarRentalRegion(CarRentalRegion carRentalRegion) {
         carRentalRegions.put(carRentalRegion.network, carRentalRegion); 
+    }
+
+    public Map<String, List<RentalUpdaterError>> getErrorsByNetwork() {
+        return errorsByNetwork;
+    }
+
+    public void setErrorsForNetwork(String network, List<RentalUpdaterError> errors) {
+        errorsByNetwork.put(network, errors);
+    }
+
+    public Map<String, SystemInformation.SystemInformationData> getSystemInformationDataByNetwork() {
+        return systemInformationDataByNetwork;
+    }
+
+    public void setSystemInformationDataForNetwork(
+        String network,
+        SystemInformation.SystemInformationData systemInformationData
+    ) {
+        systemInformationDataByNetwork.put(network, systemInformationData);
     }
 }

--- a/src/main/java/org/opentripplanner/routing/vehicle_rental/RentalStation.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_rental/RentalStation.java
@@ -35,5 +35,31 @@ public abstract class RentalStation {
     @XmlAttribute
     @JsonSerialize
     public Set<String> networks = null;
+
+    /**
+     * The last time (in epoch seconds) that this rental station had updated information. This source of this
+     * information varies according to the following fall-back methods:
+     *  - First try to use the value for a specific station or floating vehicle was updated according to the provider if
+     *  available in the feed. In the context of the GBFS this will be either the
+     *  station_status#data#stations#station#last_reported or free_bike_status#data#bikes#bike#last_reported. Note that
+     *  free_bike_status#data#bikes#bike#last_reported is available in feeds compliant with GBFS-2.1-RC+.
+     *  - If per-station or per-vehicle information is not available, try to use the feed-wide last update time. In the
+     *  context of the GBFS, this will be either the station_status#last_udated or free_bike_status#last_updated field.
+     *  - If feed-wide data on when the last report was, then use the current timestamp when the data was received by
+     *  OTP.
+     */
+    @XmlAttribute
+    @JsonSerialize
+    public Long lastReportedEpochSeconds;
+
+    /**
+     * Obtain a desired reported time using fallbacks. First try to use a station-specific value, then a feed-specific
+     * value, then the current system time. Assume that values of 0 indicate a non-set time.
+     */
+    public static Long getLastReportedTimeUsingFallbacks(Long stationSpecificValue, Integer feedSpecificValue) {
+        if (stationSpecificValue != null && stationSpecificValue > 0) return stationSpecificValue;
+        if (feedSpecificValue != null && feedSpecificValue > 0) return Long.valueOf(feedSpecificValue);
+        return System.currentTimeMillis() / 1000;
+    }
 }
 

--- a/src/main/java/org/opentripplanner/routing/vehicle_rental/RentalStation.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_rental/RentalStation.java
@@ -37,16 +37,16 @@ public abstract class RentalStation {
     public Set<String> networks = null;
 
     /**
-     * The last time (in epoch seconds) that this rental station had updated information. This source of this
+     * The last time (in epoch seconds) that this rental station had updated information. The source of this
      * information varies according to the following fall-back methods:
-     *  - First try to use the value for a specific station or floating vehicle was updated according to the provider if
+     *  - First try to use the value of the last update time for a specific station or floating vehicle if the value is
      *  available in the feed. In the context of the GBFS this will be either the
      *  station_status#data#stations#station#last_reported or free_bike_status#data#bikes#bike#last_reported. Note that
      *  free_bike_status#data#bikes#bike#last_reported is available in feeds compliant with GBFS-2.1-RC+.
      *  - If per-station or per-vehicle information is not available, try to use the feed-wide last update time. In the
      *  context of the GBFS, this will be either the station_status#last_udated or free_bike_status#last_updated field.
-     *  - If feed-wide data on when the last report was, then use the current timestamp when the data was received by
-     *  OTP.
+     *  - If feed-wide data on the last reported timestamp is not available, then use the current timestamp when the
+     *  data was received by OTP.
      */
     @XmlAttribute
     @JsonSerialize

--- a/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalStationService.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalStationService.java
@@ -13,10 +13,14 @@
 
 package org.opentripplanner.routing.vehicle_rental;
 
+import org.opentripplanner.updater.RentalUpdaterError;
+import org.opentripplanner.updater.vehicle_rental.GBFSMappings.SystemInformation;
+
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,6 +35,12 @@ public class VehicleRentalStationService implements Serializable {
     private Map<String, VehicleRentalRegion> vehicleRentalRegions = new HashMap<>();
 
     private Set<VehicleRentalStation> vehicleRentalStations = new HashSet<VehicleRentalStation>();
+
+    /* A map of vehicle network name to the latest errors encountered while fetching the feed */
+    private Map<String, List<RentalUpdaterError>> errorsByNetwork = new HashMap<>();
+
+    /* A map of vehicle network name to the latest system information data received while fetching the feed */
+    private Map<String, SystemInformation.SystemInformationData> systemInformationDataByNetwork = new HashMap<>();
 
     public Collection<VehicleRentalStation> getVehicleRentalStations() {
         return vehicleRentalStations;
@@ -52,5 +62,24 @@ public class VehicleRentalStationService implements Serializable {
     
     public void addVehicleRentalRegion(VehicleRentalRegion vehicleRentalRegion) {
         vehicleRentalRegions.put(vehicleRentalRegion.network, vehicleRentalRegion);
+    }
+
+    public Map<String, List<RentalUpdaterError>> getErrorsByNetwork() {
+        return errorsByNetwork;
+    }
+
+    public void setErrorsForNetwork(String network, List<RentalUpdaterError> errors) {
+        errorsByNetwork.put(network, errors);
+    }
+
+    public Map<String, SystemInformation.SystemInformationData> getSystemInformationDataByNetwork() {
+        return systemInformationDataByNetwork;
+    }
+
+    public void setSystemInformationDataForNetwork(
+        String network,
+        SystemInformation.SystemInformationData systemInformationData
+    ) {
+        systemInformationDataByNetwork.put(network, systemInformationData);
     }
 }

--- a/src/main/java/org/opentripplanner/updater/RentalUpdaterError.java
+++ b/src/main/java/org/opentripplanner/updater/RentalUpdaterError.java
@@ -36,6 +36,10 @@ public class RentalUpdaterError {
          */
         ALL_FLOATING_VEHICLES,
         /**
+         * An error that made it impossible to parse region information.
+         */
+        ALL_REGIONS,
+        /**
          * An error that affects just an individual docking station
          */
         INDIVIDUAL_DOCKING_STATION,

--- a/src/main/java/org/opentripplanner/updater/RentalUpdaterError.java
+++ b/src/main/java/org/opentripplanner/updater/RentalUpdaterError.java
@@ -1,0 +1,47 @@
+package org.opentripplanner.updater;
+
+public class RentalUpdaterError {
+    /**
+     * A description of the error.
+     */
+    public final String message;
+
+    /**
+     * The severity type of the error.
+     */
+    public final Severity severity;
+
+    public RentalUpdaterError(Severity severity, String message) {
+        this.message = message;
+        this.severity = severity;
+    }
+
+    public enum Severity {
+        /**
+         * An error that affects all elements of the data feed.
+         */
+        FEED_WIDE,
+        /**
+         * An error that made it impossible to parse the system information. Information about docking stations and
+         * vehicles might still be available.
+         */
+        SYSTEM_INFORMATION,
+        /**
+         * An error that made it impossible to parse the docking station information (either the station_information or
+         * station_status files)
+         */
+        ALL_STATIONS,
+        /**
+         * An error that made it impossible to parse the floating vehicle information.
+         */
+        ALL_FLOATING_VEHICLES,
+        /**
+         * An error that affects just an individual docking station
+         */
+        INDIVIDUAL_DOCKING_STATION,
+        /**
+         * An error that affects just an individual vehicle
+         */
+        INDIVIDUAL_VEHICLE
+    }
+}

--- a/src/main/java/org/opentripplanner/updater/bike_rental/BCycleBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/BCycleBikeRentalDataSource.java
@@ -3,6 +3,7 @@ package org.opentripplanner.updater.bike_rental;
 import java.util.HashSet;
 
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
+import org.opentripplanner.routing.vehicle_rental.RentalStation;
 import org.opentripplanner.util.NonLocalizedString;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -26,7 +27,7 @@ public class BCycleBikeRentalDataSource extends GenericJsonBikeRentalDataSource 
         }
     }
 
-    public BikeRentalStation makeStation(JsonNode kioskNode) {
+    public BikeRentalStation makeStation(JsonNode kioskNode, Integer feedUpdateEpochSeconds) {
 
         if (!kioskNode.path("Status").asText().equals("Active")) {
             return null;
@@ -38,6 +39,10 @@ public class BCycleBikeRentalDataSource extends GenericJsonBikeRentalDataSource 
         brstation.networks.add(this.networkName);
 
         brstation.id = kioskNode.path("Id").toString();
+        brstation.lastReportedEpochSeconds = RentalStation.getLastReportedTimeUsingFallbacks(
+            kioskNode.path("last_reported").asLong(),
+            feedUpdateEpochSeconds
+        );
         brstation.x = kioskNode.path("Location").path("Longitude").asDouble();
         brstation.y = kioskNode.path("Location").path("Latitude").asDouble();
         brstation.name =  new NonLocalizedString(kioskNode.path("Name").asText());

--- a/src/main/java/org/opentripplanner/updater/bike_rental/BCycleBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/BCycleBikeRentalDataSource.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 import org.opentripplanner.routing.vehicle_rental.RentalStation;
+import org.opentripplanner.updater.RentalUpdaterError;
 import org.opentripplanner.util.NonLocalizedString;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -19,7 +20,7 @@ public class BCycleBikeRentalDataSource extends GenericJsonBikeRentalDataSource 
     private String networkName;
 
     public BCycleBikeRentalDataSource(String apiKey, String networkName) {
-        super("", "ApiKey",apiKey);
+        super(RentalUpdaterError.Severity.ALL_STATIONS, "", "ApiKey",apiKey);
         if (networkName != null && !networkName.isEmpty()) {
             this.networkName = networkName;
         } else {

--- a/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalDataSource.java
@@ -3,22 +3,28 @@ package org.opentripplanner.updater.bike_rental;
 import java.util.List;
 
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
+import org.opentripplanner.updater.RentalUpdaterError;
+import org.opentripplanner.updater.vehicle_rental.GBFSMappings.SystemInformation;
 
 /**
  * TODO clarify thread safety.
  * It appears that update() and getStations() are never called simultaneously by different threads, but is not stated.
  */
 public interface BikeRentalDataSource {
+    /**
+     * @return a List of all errors that occurred during the most recent update.
+     */
+    List<RentalUpdaterError> getErrors();
+
+    /**
+     * @return a List of all currently known bike rental stations. The updater will use this to update the Graph.
+     */
+    List<BikeRentalStation> getStations();
 
     /**
      * Fetch current data about bike rental stations and availability from this source.
      * @return true if this operation may have changed something in the list of stations.
      */
     boolean update();
-
-    /**
-     * @return a List of all currently known bike rental stations. The updater will use this to update the Graph.
-     */
-    List<BikeRentalStation> getStations();
     
 }

--- a/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalDataSource.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 import org.opentripplanner.updater.RentalUpdaterError;
-import org.opentripplanner.updater.vehicle_rental.GBFSMappings.SystemInformation;
 
 /**
  * TODO clarify thread safety.

--- a/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalDataSource.java
@@ -12,12 +12,12 @@ import org.opentripplanner.updater.vehicle_rental.GBFSMappings.SystemInformation
  */
 public interface BikeRentalDataSource {
     /**
-     * @return a List of all errors that occurred during the most recent update.
+     * @return a list of all errors that occurred during the most recent update.
      */
     List<RentalUpdaterError> getErrors();
 
     /**
-     * @return a List of all currently known bike rental stations. The updater will use this to update the Graph.
+     * @return a list of all currently known bike rental stations. The updater will use this to update the Graph.
      */
     List<BikeRentalStation> getStations();
 

--- a/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalUpdater.java
@@ -6,15 +6,8 @@ import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 import org.opentripplanner.routing.bike_rental.BikeRentalStationService;
 import org.opentripplanner.routing.edgetype.RentABikeOffEdge;
 import org.opentripplanner.routing.edgetype.RentABikeOnEdge;
-import org.opentripplanner.routing.edgetype.SemiPermanentPartialStreetEdge;
-import org.opentripplanner.routing.edgetype.StreetBikeRentalLink;
-import org.opentripplanner.routing.edgetype.StreetEdge;
-import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.vehicle_rental.VehicleRentalStation;
 import org.opentripplanner.routing.vertextype.BikeRentalStationVertex;
-import org.opentripplanner.routing.vertextype.SemiPermanentSplitterVertex;
-import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.GraphWriterRunnable;
 import org.opentripplanner.updater.JsonConfigurable;
@@ -25,7 +18,6 @@ import org.opentripplanner.util.DateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -35,7 +27,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
-import static org.opentripplanner.graph_builder.linking.StreetSplitter.DESTRUCTIVE_SPLIT;
 import static org.opentripplanner.graph_builder.linking.StreetSplitter.NON_DESTRUCTIVE_SPLIT;
 
 /**

--- a/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalUpdater.java
@@ -195,14 +195,14 @@ public class BikeRentalUpdater extends PollingGraphUpdater {
 
             // Apply stations to graph if a feed-wide error did not occur
             if (!feedWideError) {
-                /* add any new stations that have fresh-enough data and update bike counts for existing stations */
+                // add any new stations that have fresh-enough data and update bike counts for existing stations
                 for (BikeRentalStation station : stations) {
                     if (!DateUtils.withinTimeToLive(station.lastReportedEpochSeconds, timeToLiveMinutes)) {
                         // skip station as it does not have fresh-enough data
                         continue;
                     }
                     if (station.networks == null) {
-                        /* API did not provide a network list, use default */
+                        // API did not provide a network list, use default
                         station.networks = defaultNetworks;
                     }
                     service.addBikeRentalStation(station);
@@ -225,7 +225,7 @@ public class BikeRentalUpdater extends PollingGraphUpdater {
                 }
             }
 
-            /* remove existing stations that were not present in the update */
+            // remove existing stations that were not present in the update
             for (Entry<BikeRentalStation, BikeRentalStationVertex> entry : verticesByStation.entrySet()) {
                 BikeRentalStation station = entry.getKey();
                 if (stationsInUpdate.contains(station)) {

--- a/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalUpdater.java
@@ -54,6 +54,8 @@ public class BikeRentalUpdater extends PollingGraphUpdater {
 
     private int timeToLiveMinutes;
 
+    private String networkName = "default";
+
     @Override
     public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
         this.updaterManager = updaterManager;
@@ -67,7 +69,7 @@ public class BikeRentalUpdater extends PollingGraphUpdater {
         String apiKey = config.path("apiKey").asText();
         // Each updater can be assigned a unique network ID in the configuration to prevent returning bikes at
         // stations for another network. TODO shouldn't we give each updater a unique network ID by default?
-        String networkName = config.path("network").asText();
+        networkName = config.path("network").asText();
         BikeRentalDataSource source = null;
         if (sourceType != null) {
             if (sourceType.equals("jcdecaux")) {
@@ -157,8 +159,8 @@ public class BikeRentalUpdater extends PollingGraphUpdater {
 
 		@Override
         public void run(Graph graph) {
-            service.setErrorsForNetwork(network, errors);
-            service.setSystemInformationDataForNetwork(network, systemInformationData);
+            service.setErrorsForNetwork(networkName, errors);
+            service.setSystemInformationDataForNetwork(networkName, systemInformationData);
 
             // check if any critical errors occurred
             boolean feedWideError = false;

--- a/src/main/java/org/opentripplanner/updater/bike_rental/CitiBikeNycBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/CitiBikeNycBikeRentalDataSource.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 import org.opentripplanner.routing.vehicle_rental.RentalStation;
+import org.opentripplanner.updater.RentalUpdaterError;
 import org.opentripplanner.util.NonLocalizedString;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -19,7 +20,7 @@ public class CitiBikeNycBikeRentalDataSource extends GenericJsonBikeRentalDataSo
     private String networkName;
 
     public CitiBikeNycBikeRentalDataSource(String networkName) {
-        super("stationBeanList");
+        super(RentalUpdaterError.Severity.ALL_STATIONS, "stationBeanList");
         if (networkName != null && !networkName.isEmpty()) {
             this.networkName = networkName;
         } else {

--- a/src/main/java/org/opentripplanner/updater/bike_rental/CitiBikeNycBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/CitiBikeNycBikeRentalDataSource.java
@@ -3,6 +3,7 @@ package org.opentripplanner.updater.bike_rental;
 import java.util.HashSet;
 
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
+import org.opentripplanner.routing.vehicle_rental.RentalStation;
 import org.opentripplanner.util.NonLocalizedString;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -26,7 +27,7 @@ public class CitiBikeNycBikeRentalDataSource extends GenericJsonBikeRentalDataSo
         }
     }
 
-    public BikeRentalStation makeStation(JsonNode stationNode) {
+    public BikeRentalStation makeStation(JsonNode stationNode, Integer feedUpdateEpochSeconds) {
 
         if (!stationNode.path("statusValue").asText().equals("In Service")) {
             return null;
@@ -42,6 +43,10 @@ public class CitiBikeNycBikeRentalDataSource extends GenericJsonBikeRentalDataSo
         brstation.networks.add(this.networkName);
 
         brstation.id = stationNode.path("id").toString();
+        brstation.lastReportedEpochSeconds = RentalStation.getLastReportedTimeUsingFallbacks(
+            stationNode.path("last_reported").asLong(),
+            feedUpdateEpochSeconds
+        );
         brstation.x = stationNode.path("longitude").asDouble();
         brstation.y = stationNode.path("latitude").asDouble();
         brstation.name =  new NonLocalizedString(stationNode.path("stationName").asText());

--- a/src/main/java/org/opentripplanner/updater/bike_rental/GbfsBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/GbfsBikeRentalDataSource.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.vehicle_rental.RentalStation;
 import org.opentripplanner.updater.JsonConfigurable;
 import org.opentripplanner.updater.vehicle_rental.GBFSMappings.GbfsResponse;
 import org.opentripplanner.util.NonLocalizedString;
@@ -240,12 +241,16 @@ public class GbfsBikeRentalDataSource implements BikeRentalDataSource, JsonConfi
         }
 
         @Override
-        public BikeRentalStation makeStation(JsonNode stationNode) {
+        public BikeRentalStation makeStation(JsonNode stationNode, Integer feedUpdateEpochSeconds) {
             BikeRentalStation brstation = new BikeRentalStation();
             brstation.id = stationNode.path("station_id").toString();
             brstation.x = stationNode.path("lon").asDouble();
             brstation.y = stationNode.path("lat").asDouble();
             brstation.name =  new NonLocalizedString(stationNode.path("name").asText());
+            brstation.lastReportedEpochSeconds = RentalStation.getLastReportedTimeUsingFallbacks(
+                stationNode.path("last_reported").asLong(),
+                feedUpdateEpochSeconds
+            );
             brstation.isCarStation = routeAsCar;
             return brstation;
         }
@@ -258,11 +263,15 @@ public class GbfsBikeRentalDataSource implements BikeRentalDataSource, JsonConfi
         }
 
         @Override
-        public BikeRentalStation makeStation(JsonNode stationNode) {
+        public BikeRentalStation makeStation(JsonNode stationNode, Integer feedUpdateEpochSeconds) {
             BikeRentalStation brstation = new BikeRentalStation();
             brstation.id = stationNode.path("station_id").toString();
             brstation.bikesAvailable = stationNode.path("num_bikes_available").asInt();
             brstation.spacesAvailable = stationNode.path("num_docks_available").asInt();
+            brstation.lastReportedEpochSeconds = RentalStation.getLastReportedTimeUsingFallbacks(
+                stationNode.path("last_reported").asLong(),
+                feedUpdateEpochSeconds
+            );
             brstation.isCarStation = routeAsCar;
             return brstation;
         }
@@ -275,12 +284,16 @@ public class GbfsBikeRentalDataSource implements BikeRentalDataSource, JsonConfi
         }
 
         @Override
-        public BikeRentalStation makeStation(JsonNode stationNode) {
+        public BikeRentalStation makeStation(JsonNode stationNode, Integer feedUpdateEpochSeconds) {
             BikeRentalStation brstation = new BikeRentalStation();
             brstation.id = stationNode.path("bike_id").toString();
             brstation.name = new NonLocalizedString(stationNode.path("name").asText());
             brstation.x = stationNode.path("lon").asDouble();
             brstation.y = stationNode.path("lat").asDouble();
+            brstation.lastReportedEpochSeconds = RentalStation.getLastReportedTimeUsingFallbacks(
+                stationNode.path("last_reported").asLong(),
+                feedUpdateEpochSeconds
+            );
             brstation.bikesAvailable = 1;
             brstation.spacesAvailable = 0;
             brstation.allowDropoff = false;

--- a/src/main/java/org/opentripplanner/updater/bike_rental/GbfsBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/GbfsBikeRentalDataSource.java
@@ -64,12 +64,19 @@ public class GbfsBikeRentalDataSource implements BikeRentalDataSource, JsonConfi
         errors = new LinkedList<>();
         updateUrls();
         // These first two GBFS files are required.
-        boolean updatesFound = stationInformationSource.update();
-        updatesFound |= stationStatusSource.update();
+        boolean stationInfoFound = stationInformationSource.update();
+        stationInfoFound &= stationStatusSource.update();
         // This floating-bikes file is optional, and does not appear in all GBFS feeds.
-        updatesFound |= floatingBikeSource.update();
+        boolean floatingInfoFound = floatingBikeSource.update();
+
+        // since a GBFS may not need a GBFS.json file, create a feed-wide error if there was a problem fetching both the
+        // station information and floating vehicle info
+        if (!stationInfoFound && !floatingInfoFound) {
+            addError(RentalUpdaterError.Severity.FEED_WIDE, "Both station and vehicle info not found!");
+        }
+
         // Return true if ANY of the sub-updaters found any updates.
-        return updatesFound;
+        return stationInfoFound || floatingInfoFound;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/updater/bike_rental/GbfsBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/GbfsBikeRentalDataSource.java
@@ -63,10 +63,9 @@ public class GbfsBikeRentalDataSource implements BikeRentalDataSource, JsonConfi
     public boolean update() {
         errors = new LinkedList<>();
         updateUrls();
-        // These first two GBFS files are required.
-        boolean stationInfoFound = stationInformationSource.update();
-        stationInfoFound &= stationStatusSource.update();
-        // This floating-bikes file is optional, and does not appear in all GBFS feeds.
+        // Get information about stations
+        boolean stationInfoFound = stationInformationSource.update() && stationStatusSource.update();
+        // Get info about floating-bikes.
         boolean floatingInfoFound = floatingBikeSource.update();
 
         // since a GBFS may not need a GBFS.json file, create a feed-wide error if there was a problem fetching both the
@@ -90,7 +89,7 @@ public class GbfsBikeRentalDataSource implements BikeRentalDataSource, JsonConfi
      * Adds an error message to the list of errors and also logs the error message.
      */
     private void addError(RentalUpdaterError.Severity severity, String message) {
-        message = String.format("%s (feed: %s)", message, networkName);
+        message = String.format("%s (network: %s)", message, networkName);
         errors.add(new RentalUpdaterError(severity, message));
         LOG.error(String.format("[severity: %s] %s", severity, message));
     }

--- a/src/main/java/org/opentripplanner/updater/bike_rental/GenericJsonBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/GenericJsonBikeRentalDataSource.java
@@ -111,6 +111,8 @@ public abstract class GenericJsonBikeRentalDataSource implements BikeRentalDataS
         ObjectMapper mapper = new ObjectMapper();
         JsonNode rootNode = mapper.readTree(rentalString);
 
+        Integer feedUpdateEpochSeconds = rootNode.path("last_updated").asInt();
+
         if (!jsonParsePath.equals("")) {
             String delimiter = "/";
             String[] parseElement = jsonParsePath.split(delimiter);
@@ -129,7 +131,7 @@ public abstract class GenericJsonBikeRentalDataSource implements BikeRentalDataS
             if (node == null) {
                 continue;
             }
-            BikeRentalStation brstation = makeStation(node);
+            BikeRentalStation brstation = makeStation(node, feedUpdateEpochSeconds);
             if (brstation != null)
                 out.add(brstation);
         }
@@ -169,7 +171,7 @@ public abstract class GenericJsonBikeRentalDataSource implements BikeRentalDataS
     	this.url = url;
     }
 
-    public abstract BikeRentalStation makeStation(JsonNode rentalStationNode);
+    public abstract BikeRentalStation makeStation(JsonNode rentalStationNode, Integer feedUpdateEpochSeconds);
 
     @Override
     public String toString() {

--- a/src/main/java/org/opentripplanner/updater/bike_rental/GenericJsonBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/GenericJsonBikeRentalDataSource.java
@@ -113,7 +113,9 @@ public abstract class GenericJsonBikeRentalDataSource implements BikeRentalDataS
             return false;
         } finally {
             try {
-                data.close();
+                if (data != null) {
+                    data.close();
+                }
             } catch (IOException e) {
                 log.warn("An error occurred while closing data stream {}");
                 e.printStackTrace();

--- a/src/main/java/org/opentripplanner/updater/bike_rental/GenericJsonBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/GenericJsonBikeRentalDataSource.java
@@ -48,8 +48,8 @@ public abstract class GenericJsonBikeRentalDataSource implements BikeRentalDataS
     /**
      * Construct superclass
      *
-     * @param severityFailureType The severity level to create an error with when fetching from this particular data
-     *                            source. This can be used to differentiate different error types for fetching from
+     * @param severityFailureType The severity level given to an error with when fetching from this particular data
+     *                            source. This can be used to define different error types when fetching from
      *                            stations of floating vehicles for example.
      * @param jsonPath JSON path to get from enclosing elements to nested rental list.
      *        Separate path levels with '/' For example "d/list"
@@ -61,8 +61,8 @@ public abstract class GenericJsonBikeRentalDataSource implements BikeRentalDataS
 
     /**
      *
-     * @param severityFailureType The severity level to create an error with when fetching from this particular data
-     *                            source. This can be used to differentiate different error types for fetching from
+     * @param severityFailureType The severity level given to an error with when fetching from this particular data
+     *                            source. This can be used to define different error types when fetching from
      *                            stations of floating vehicles for example.
      * @param jsonPath path to get from enclosing elements to nested rental list.
      *        Separate path levels with '/' For example "d/list"

--- a/src/main/java/org/opentripplanner/updater/bike_rental/JCDecauxBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/JCDecauxBikeRentalDataSource.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.updater.bike_rental;
 
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
+import org.opentripplanner.routing.vehicle_rental.RentalStation;
 import org.opentripplanner.util.NonLocalizedString;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -40,12 +41,16 @@ public class JCDecauxBikeRentalDataSource extends GenericJsonBikeRentalDataSourc
      * ]
      * </pre>
      */
-    public BikeRentalStation makeStation(JsonNode node) {
+    public BikeRentalStation makeStation(JsonNode node, Integer feedUpdateEpochSeconds) {
         if (!node.path("status").asText().equals("OPEN")) {
             return null;
         }
         BikeRentalStation station = new BikeRentalStation();
         station.id = String.format("%d", node.path("number").asInt());
+        station.lastReportedEpochSeconds = RentalStation.getLastReportedTimeUsingFallbacks(
+            node.path("last_update").asLong() / 1000,
+            feedUpdateEpochSeconds
+        );
         station.x = node.path("position").path("lng").asDouble();
         station.y = node.path("position").path("lat").asDouble();
         station.name = new NonLocalizedString(node.path("name").asText());

--- a/src/main/java/org/opentripplanner/updater/bike_rental/JCDecauxBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/JCDecauxBikeRentalDataSource.java
@@ -2,6 +2,7 @@ package org.opentripplanner.updater.bike_rental;
 
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 import org.opentripplanner.routing.vehicle_rental.RentalStation;
+import org.opentripplanner.updater.RentalUpdaterError;
 import org.opentripplanner.util.NonLocalizedString;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -15,7 +16,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 public class JCDecauxBikeRentalDataSource extends GenericJsonBikeRentalDataSource {
 
     public JCDecauxBikeRentalDataSource() {
-        super("");
+        super(RentalUpdaterError.Severity.ALL_STATIONS, "");
     }
 
     /**

--- a/src/main/java/org/opentripplanner/updater/bike_rental/SanFranciscoBayAreaBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/SanFranciscoBayAreaBikeRentalDataSource.java
@@ -2,6 +2,7 @@ package org.opentripplanner.updater.bike_rental;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
+import org.opentripplanner.routing.vehicle_rental.RentalStation;
 import org.opentripplanner.util.NonLocalizedString;
 
 import java.util.HashSet;
@@ -25,7 +26,7 @@ public class SanFranciscoBayAreaBikeRentalDataSource extends GenericJsonBikeRent
         }
     }
 
-    public BikeRentalStation makeStation(JsonNode stationNode) {
+    public BikeRentalStation makeStation(JsonNode stationNode, Integer feedUpdateEpochSeconds) {
 
         if (!stationNode.path("statusValue").asText().equals("In Service")) {
             return null;
@@ -41,6 +42,10 @@ public class SanFranciscoBayAreaBikeRentalDataSource extends GenericJsonBikeRent
         brstation.networks.add(this.networkName);
 
         brstation.id = stationNode.path("id").toString();
+        brstation.lastReportedEpochSeconds = RentalStation.getLastReportedTimeUsingFallbacks(
+            stationNode.path("last_reported").asLong(),
+            feedUpdateEpochSeconds
+        );
         brstation.x = stationNode.path("longitude").asDouble();
         brstation.y = stationNode.path("latitude").asDouble();
         brstation.name =  new NonLocalizedString(stationNode.path("stationName").asText());

--- a/src/main/java/org/opentripplanner/updater/bike_rental/SanFranciscoBayAreaBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/SanFranciscoBayAreaBikeRentalDataSource.java
@@ -3,6 +3,7 @@ package org.opentripplanner.updater.bike_rental;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 import org.opentripplanner.routing.vehicle_rental.RentalStation;
+import org.opentripplanner.updater.RentalUpdaterError;
 import org.opentripplanner.util.NonLocalizedString;
 
 import java.util.HashSet;
@@ -18,7 +19,7 @@ public class SanFranciscoBayAreaBikeRentalDataSource extends GenericJsonBikeRent
     private String networkName;
 
     public SanFranciscoBayAreaBikeRentalDataSource(String networkName) {
-        super("stationBeanList");
+        super(RentalUpdaterError.Severity.ALL_STATIONS, "stationBeanList");
         if (networkName != null && !networkName.isEmpty()) {
             this.networkName = networkName;
         } else {

--- a/src/main/java/org/opentripplanner/updater/bike_rental/ShareBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/ShareBikeRentalDataSource.java
@@ -3,6 +3,7 @@ package org.opentripplanner.updater.bike_rental;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 import org.opentripplanner.routing.vehicle_rental.RentalStation;
+import org.opentripplanner.updater.RentalUpdaterError;
 import org.opentripplanner.util.NonLocalizedString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,7 +23,7 @@ public class ShareBikeRentalDataSource extends GenericJsonBikeRentalDataSource {
 	private Map<String, List<String>> urlParameters = new HashMap<>();
 
 	public ShareBikeRentalDataSource() throws UnsupportedEncodingException, MalformedURLException {
-		super("result/LiveStationData");
+		super(RentalUpdaterError.Severity.ALL_STATIONS, "result/LiveStationData");
 	}
 
 	/**

--- a/src/main/java/org/opentripplanner/updater/bike_rental/ShareBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/ShareBikeRentalDataSource.java
@@ -2,6 +2,7 @@ package org.opentripplanner.updater.bike_rental;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
+import org.opentripplanner.routing.vehicle_rental.RentalStation;
 import org.opentripplanner.util.NonLocalizedString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +63,7 @@ public class ShareBikeRentalDataSource extends GenericJsonBikeRentalDataSource {
 	 */
 
 	@Override
-	public BikeRentalStation makeStation(JsonNode rentalStationNode) {
+	public BikeRentalStation makeStation(JsonNode rentalStationNode, Integer feedUpdateEpochSeconds) {
 
 		if(networkID == null) {
 			// Get SystemID url parameter as StationIDs are not globally unique for
@@ -90,6 +91,10 @@ public class ShareBikeRentalDataSource extends GenericJsonBikeRentalDataSource {
         brstation.networks.add(this.networkID);
 		
 		brstation.id = networkID+"_"+rentalStationNode.path("StationID").toString();
+		brstation.lastReportedEpochSeconds = RentalStation.getLastReportedTimeUsingFallbacks(
+			rentalStationNode.path("LastContactSeconds").asLong(),
+			feedUpdateEpochSeconds
+		);
 		brstation.x = rentalStationNode.path("Longitude").asDouble();
 		brstation.y = rentalStationNode.path("Latitude").asDouble();
 		brstation.name = new NonLocalizedString(rentalStationNode.path("StationName").asText("").trim());

--- a/src/main/java/org/opentripplanner/updater/bike_rental/SmooveBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/SmooveBikeRentalDataSource.java
@@ -14,6 +14,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 package org.opentripplanner.updater.bike_rental;
 
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
+import org.opentripplanner.routing.vehicle_rental.RentalStation;
 import org.opentripplanner.util.NonLocalizedString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +51,7 @@ public class SmooveBikeRentalDataSource extends GenericJsonBikeRentalDataSource 
      * }
      * </pre>
      */
-    public BikeRentalStation makeStation(JsonNode node) {
+    public BikeRentalStation makeStation(JsonNode node, Integer feedUpdateEpochSeconds) {
         BikeRentalStation station = new BikeRentalStation();
         station.id = node.path("name").asText().split("\\s", 2)[0];
         station.name = new NonLocalizedString(node.path("name").asText().split("\\s", 2)[1]);
@@ -70,6 +71,10 @@ public class SmooveBikeRentalDataSource extends GenericJsonBikeRentalDataSource 
             station.bikesAvailable = node.path("avl_bikes").asInt();
             station.spacesAvailable = node.path("free_slots").asInt();
         }
+        station.lastReportedEpochSeconds = RentalStation.getLastReportedTimeUsingFallbacks(
+            node.path("last_reported").asLong(),
+            feedUpdateEpochSeconds
+        );
         return station;
     }
 }

--- a/src/main/java/org/opentripplanner/updater/bike_rental/SmooveBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/SmooveBikeRentalDataSource.java
@@ -15,6 +15,7 @@ package org.opentripplanner.updater.bike_rental;
 
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 import org.opentripplanner.routing.vehicle_rental.RentalStation;
+import org.opentripplanner.updater.RentalUpdaterError;
 import org.opentripplanner.util.NonLocalizedString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,7 +31,7 @@ public class SmooveBikeRentalDataSource extends GenericJsonBikeRentalDataSource 
     private static final Logger log = LoggerFactory.getLogger(SmooveBikeRentalDataSource.class);
 
     public SmooveBikeRentalDataSource() {
-        super("result");
+        super(RentalUpdaterError.Severity.ALL_STATIONS, "result");
     }
 
     /**
@@ -61,7 +62,10 @@ public class SmooveBikeRentalDataSource extends GenericJsonBikeRentalDataSource 
             station.x = Double.parseDouble(coordinates[1].trim());
         } catch (NumberFormatException e) {
             // E.g. coordinates is empty
-            log.warn("Error parsing bike rental station " + station.id, e);
+            errors.add(new RentalUpdaterError(
+                RentalUpdaterError.Severity.INDIVIDUAL_DOCKING_STATION,
+                "Error parsing bike rental station " + station.id
+            ));
             return null;
         }
         if (!node.path("operative").asText().equals("true")) {

--- a/src/main/java/org/opentripplanner/updater/bike_rental/UIPBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/UIPBikeRentalDataSource.java
@@ -3,6 +3,7 @@ package org.opentripplanner.updater.bike_rental;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
+import org.opentripplanner.routing.vehicle_rental.RentalStation;
 import org.opentripplanner.util.NonLocalizedString;
 
 import java.util.ArrayList;
@@ -24,10 +25,14 @@ public class UIPBikeRentalDataSource extends GenericJsonBikeRentalDataSource {
      *
      */
     @Override
-    public BikeRentalStation makeStation(JsonNode rentalStationNode) {
+    public BikeRentalStation makeStation(JsonNode rentalStationNode, Integer feedUpdateEpochSeconds) {
         BikeRentalStation brstation = new BikeRentalStation();
 
         brstation.id = rentalStationNode.path("id").toString();
+        brstation.lastReportedEpochSeconds = RentalStation.getLastReportedTimeUsingFallbacks(
+            rentalStationNode.path("last_reported").asLong(),
+            feedUpdateEpochSeconds
+        );
         brstation.name = new NonLocalizedString(rentalStationNode.path("title").asText("").trim());
         brstation.x = rentalStationNode.path("center").path("longitude").asDouble();
         brstation.y = rentalStationNode.path("center").path("latitude").asDouble();

--- a/src/main/java/org/opentripplanner/updater/bike_rental/UIPBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/UIPBikeRentalDataSource.java
@@ -4,6 +4,7 @@ package org.opentripplanner.updater.bike_rental;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 import org.opentripplanner.routing.vehicle_rental.RentalStation;
+import org.opentripplanner.updater.RentalUpdaterError;
 import org.opentripplanner.util.NonLocalizedString;
 
 import java.util.ArrayList;
@@ -14,7 +15,7 @@ public class UIPBikeRentalDataSource extends GenericJsonBikeRentalDataSource {
     private String baseURL = null;
 
     UIPBikeRentalDataSource(String apiKey) {
-        super("stations", "Client-Identifier", apiKey);
+        super(RentalUpdaterError.Severity.ALL_STATIONS, "stations", "Client-Identifier", apiKey);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/updater/car_rental/Car2GoCarRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/car_rental/Car2GoCarRentalDataSource.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opentripplanner.routing.car_rental.CarFuelType;
 import org.opentripplanner.routing.car_rental.CarRentalStation;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.updater.RentalUpdaterError;
 import org.opentripplanner.util.NonLocalizedString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,7 +14,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 
 public class Car2GoCarRentalDataSource extends GenericCarRentalDataSource {
     private static final Logger LOG = LoggerFactory.getLogger(Car2GoCarRentalDataSource.class);

--- a/src/main/java/org/opentripplanner/updater/car_rental/Car2GoCarRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/car_rental/Car2GoCarRentalDataSource.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opentripplanner.routing.car_rental.CarFuelType;
 import org.opentripplanner.routing.car_rental.CarRentalStation;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.updater.RentalUpdaterError;
 import org.opentripplanner.util.NonLocalizedString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,6 +15,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 
 public class Car2GoCarRentalDataSource extends GenericCarRentalDataSource {
     private static final Logger LOG = LoggerFactory.getLogger(Car2GoCarRentalDataSource.class);
@@ -55,5 +57,4 @@ public class Car2GoCarRentalDataSource extends GenericCarRentalDataSource {
 
         return car2go;
     }
-
 }

--- a/src/main/java/org/opentripplanner/updater/car_rental/CarRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/car_rental/CarRentalDataSource.java
@@ -22,17 +22,17 @@ import java.util.List;
 public interface CarRentalDataSource {
 
     /**
-     * @return a List of all errors that occurred during the most recent update.
+     * @return a list of all errors that occurred during the most recent update.
      */
     List<RentalUpdaterError> getErrors();
 
     /**
-     * @return a List of all currently known car rental stations. The updater will use this to update the Graph.
+     * @return a list of all currently known car rental stations. The updater will use this to update the Graph.
      */
     List<CarRentalStation> getStations();
 
     /**
-     * @return a List of all currently known car rental regions. The updater will use this to update the Graph.
+     * @return a list of all currently known car rental regions. The updater will use this to update the Graph.
      */
     List<CarRentalRegion> getRegions();
 

--- a/src/main/java/org/opentripplanner/updater/car_rental/CarRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/car_rental/CarRentalDataSource.java
@@ -15,18 +15,16 @@ package org.opentripplanner.updater.car_rental;
 
 import org.opentripplanner.routing.car_rental.CarRentalRegion;
 import org.opentripplanner.routing.car_rental.CarRentalStation;
+import org.opentripplanner.updater.RentalUpdaterError;
 
 import java.util.List;
 
 public interface CarRentalDataSource {
 
-    /** Update the regions from the source;
-     * returns true if there might have been changes */
-    boolean updateRegions();
-
-    /** Update the stations from the source;
-     * returns true if there might have been changes */
-    boolean updateStations();
+    /**
+     * @return a List of all errors that occurred during the most recent update.
+     */
+    List<RentalUpdaterError> getErrors();
 
     /**
      * @return a List of all currently known car rental stations. The updater will use this to update the Graph.
@@ -38,4 +36,9 @@ public interface CarRentalDataSource {
      */
     List<CarRentalRegion> getRegions();
 
+    /** returns true if the regions have been updated since the last updated */
+    boolean regionsUpdated();
+
+    /** updates to the latest data */
+    void update();
 }

--- a/src/main/java/org/opentripplanner/updater/car_rental/CarRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/car_rental/CarRentalUpdater.java
@@ -166,7 +166,7 @@ public class CarRentalUpdater extends PollingGraphUpdater {
 
             // Apply stations to graph if a feed-wide error did not occur
             if (!feedWideError) {
-                /* add any new stations that have fresh-enough data and update vehicle counts for existing stations */
+                // add any new stations that have fresh-enough data and update vehicle counts for existing stations
                 for (CarRentalStation station : stations) {
                     if (!DateUtils.withinTimeToLive(station.lastReportedEpochSeconds, timeToLiveMinutes)) {
                         // skip station as it does not have fresh-enough data

--- a/src/main/java/org/opentripplanner/updater/car_rental/CarRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/car_rental/CarRentalUpdater.java
@@ -22,6 +22,8 @@ import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.GraphWriterRunnable;
 import org.opentripplanner.updater.JsonConfigurable;
 import org.opentripplanner.updater.PollingGraphUpdater;
+import org.opentripplanner.updater.RentalUpdaterError;
+import org.opentripplanner.updater.vehicle_rental.GBFSMappings.SystemInformation;
 import org.opentripplanner.util.DateUtils;
 import org.opentripplanner.util.NonLocalizedString;
 import org.slf4j.Logger;
@@ -29,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -65,22 +66,10 @@ public class CarRentalUpdater extends PollingGraphUpdater {
     @Override
     protected void runPolling() throws Exception {
         LOG.debug("Updating car rental stations and regions from " + source);
-        List<CarRentalRegion> regions = new ArrayList<>();
-        List<CarRentalStation> stations = new ArrayList<>();
-        if (source.updateStations()) {
-            stations = source.getStations();
-        } else {
-            LOG.debug("No station updates");
-        }
-
-        if (source.updateRegions()) {
-            regions = source.getRegions();
-        } else {
-            LOG.debug("No region updates");
-        }
+        source.update();
 
         // Create graph writer runnable to apply these stations and regions to the graph
-        updaterManager.execute(new CarRentalGraphWriterRunnable(stations, regions));
+        updaterManager.execute(new CarRentalGraphWriterRunnable(source));
     }
 
     @Override
@@ -127,67 +116,116 @@ public class CarRentalUpdater extends PollingGraphUpdater {
     public void teardown() {}
 
     private class CarRentalGraphWriterRunnable implements GraphWriterRunnable {
-        private List<CarRentalStation> stations;
-        private List<CarRentalRegion> regions;
+        private final List<RentalUpdaterError> errors;
+        private final List<CarRentalRegion> regions;
+        private final boolean regionsUpdated;
+        private final List<CarRentalStation> stations;
+        private final SystemInformation.SystemInformationData systemInformationData;
+
         private GeometryFactory geometryFactory = new GeometryFactory();
 
 
-        public CarRentalGraphWriterRunnable(List<CarRentalStation> stations, List<CarRentalRegion> regions) {
-            this.stations = stations;
-            this.regions = regions;
+        public CarRentalGraphWriterRunnable(CarRentalDataSource source) {
+            errors = source.getErrors();
+            regions = source.getRegions();
+            regionsUpdated = source.regionsUpdated();
+            stations = source.getStations();
+            systemInformationData = null;
         }
 
         @Override
         public void run(Graph graph) {
-            if (!this.stations.isEmpty()) {
-                applyStations(graph);
-            }
-            if (!this.regions.isEmpty()) {
-                applyRegions(graph);
-            }
+            applyStations(graph);
+            applyRegions(graph);
+            service.setErrorsForNetwork(network, errors);
+            service.setSystemInformationDataForNetwork(network, systemInformationData);
         }
 
         private void applyStations(Graph graph) {
-            // Apply stations to graph
-            Set<CarRentalStation> stationSet = new HashSet<>();
-            Set<String> defaultNetworks = new HashSet<>(Arrays.asList(network));
-            LOG.info("Updating {} rental car stations for network {}.", stations.size(), network);
-            /* add any new stations that have fresh-enough data and update car counts for existing stations */
-            for (CarRentalStation station : stations) {
-                if (!DateUtils.withinTimeToLive(station.lastReportedEpochSeconds, timeToLiveMinutes)) {
-                    // skip station as it does not have fresh-enough data
-                    continue;
-                }
-                service.addCarRentalStation(station);
-                stationSet.add(station);
-                CarRentalStationVertex vertex = verticesByStation.get(station);
-                if (vertex == null) {
-                    makeVertex(graph, station);
-                } else if (vertex.hasDifferentApproximatePosition(station)) {
-                    LOG.info("Rental car {} has changed position, re-graphing", station);
-
-                    // First remove the old vertices and edges
-                    splitter.removeRentalStationVertexAndAssociatedSemiPermanentVerticesAndEdges(vertex);
-
-                    // then make a new vertices and edges
-                    makeVertex(graph, station);
-                } else {
-                    vertex.setCarsAvailable(station.carsAvailable);
-                    vertex.setSpacesAvailable(station.spacesAvailable);
+            // check if any critical errors occurred
+            boolean feedWideError = false;
+            boolean allStationsError = false;
+            boolean allFloatingVehiclesError = false;
+            for (RentalUpdaterError error : errors) {
+                switch (error.severity) {
+                case FEED_WIDE:
+                    feedWideError = true;
+                    break;
+                case ALL_STATIONS:
+                    allStationsError = true;
+                    break;
+                case ALL_FLOATING_VEHICLES:
+                    allFloatingVehiclesError = true;
+                    break;
                 }
             }
-            // Remove existing stations that were not present in the update
-            List<CarRentalStation> toRemove = new ArrayList<>();
+
+            Set<CarRentalStation> toRemove = new HashSet<>();
+            Set<CarRentalStation> stationsInUpdate = new HashSet<>();
+            LOG.info("Updating car rental stations for network {}.", network);
+
+            // Apply stations to graph if a feed-wide error did not occur
+            if (!feedWideError) {
+                /* add any new stations that have fresh-enough data and update vehicle counts for existing stations */
+                for (CarRentalStation station : stations) {
+                    if (!DateUtils.withinTimeToLive(station.lastReportedEpochSeconds, timeToLiveMinutes)) {
+                        // skip station as it does not have fresh-enough data
+                        continue;
+                    }
+                    service.addCarRentalStation(station);
+                    stationsInUpdate.add(station);
+                    CarRentalStationVertex vertex = verticesByStation.get(station);
+                    if (vertex == null) {
+                        makeVertex(graph, station);
+                    } else if (vertex.hasDifferentApproximatePosition(station)) {
+                        LOG.info("Rental car {} has changed position, re-graphing", station);
+
+                        // First remove the old vertices and edges
+                        splitter.removeRentalStationVertexAndAssociatedSemiPermanentVerticesAndEdges(vertex);
+
+                        // then make a new vertices and edges
+                        makeVertex(graph, station);
+                    } else {
+                        vertex.setCarsAvailable(station.carsAvailable);
+                        vertex.setSpacesAvailable(station.spacesAvailable);
+                    }
+                }
+            }
+
+            // Add stations that were not present in the update to a list of stations to remove
             for (Entry<CarRentalStation, CarRentalStationVertex> entry : verticesByStation.entrySet()) {
                 CarRentalStation station = entry.getKey();
-                if (stationSet.contains(station))
+                if (stationsInUpdate.contains(station)) {
+                    // station present in update, do not remove
                     continue;
+                }
+
+                // if there was an error with fetching stations, do not remove any stations that had a last reported
+                // time within the time to live threshold
+                if (
+                    allStationsError &&
+                        !station.isFloatingCar &&
+                        DateUtils.withinTimeToLive(station.lastReportedEpochSeconds, timeToLiveMinutes)
+                ) {
+                    continue;
+                }
+
+                // if there was an error with fetching floating vehicles, do not remove any stations that had a last
+                // reported time within the time to live threshold
+                if (
+                    allFloatingVehiclesError &&
+                        station.isFloatingCar &&
+                        DateUtils.withinTimeToLive(station.lastReportedEpochSeconds, timeToLiveMinutes)
+                ) {
+                    continue;
+                }
 
                 splitter.removeRentalStationVertexAndAssociatedSemiPermanentVerticesAndEdges(entry.getValue());
 
                 toRemove.add(station);
                 service.removeCarRentalStation(station);
             }
+
             for (CarRentalStation station : toRemove) {
                 // post-iteration removal to avoid concurrent modification
                 verticesByStation.remove(station);
@@ -208,6 +246,8 @@ public class CarRentalUpdater extends PollingGraphUpdater {
         }
 
         public void applyRegions(Graph graph) {
+            if (!regionsUpdated) return;
+
             // Adding car service regions to all edges of the network.
             LOG.info("Applying {} rental car regions.", regions.size());
             Collection<StreetEdge> edges = graph.getStreetEdges();

--- a/src/main/java/org/opentripplanner/updater/car_rental/CarRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/car_rental/CarRentalUpdater.java
@@ -30,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.text.DecimalFormat;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/GBFSMappings/FreeBikeStatus.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/GBFSMappings/FreeBikeStatus.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 /**
  * Response class for the free_bike_status.json file.
- * See https://github.com/NABSA/gbfs/blob/master/gbfs.md#free_bike_statusjson
+ * See https://github.com/NABSA/gbfs/blob/v1.0/gbfs.md#free_bike_statusjson
  */
 public class FreeBikeStatus extends BaseGtfsResponse {
     public FreeBikeStatusData data;

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/GBFSMappings/FreeBikeStatus.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/GBFSMappings/FreeBikeStatus.java
@@ -19,5 +19,7 @@ public class FreeBikeStatus extends BaseGtfsResponse {
         public Double lon;
         public Boolean is_reserved;
         public Boolean is_disabled;
+        /** This field is only available starting in GBFS 2.1-RC+ */
+        public Long last_reported;
     }
 }

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/GBFSMappings/StationInformation.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/GBFSMappings/StationInformation.java
@@ -5,7 +5,7 @@ import java.util.Set;
 
 /**
  * Response class for the station_information.json file.
- * See https://github.com/NABSA/gbfs/blob/master/gbfs.md#station_informationjson
+ * See https://github.com/NABSA/gbfs/blob/v1.0/gbfs.md#station_informationjson
  */
 public class StationInformation extends BaseGtfsResponse {
     public StationInformationData data;

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/GBFSMappings/StationStatus.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/GBFSMappings/StationStatus.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 /**
  * Response class for the station_status.json file.
- * See https://github.com/NABSA/gbfs/blob/master/gbfs.md#station_statusjson
+ * See https://github.com/NABSA/gbfs/blob/v1.0/gbfs.md#station_statusjson
  */
 public class StationStatus extends BaseGtfsResponse {
     public StationStatusData data;

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/GBFSMappings/SystemInformation.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/GBFSMappings/SystemInformation.java
@@ -1,0 +1,29 @@
+package org.opentripplanner.updater.vehicle_rental.GBFSMappings;
+
+import java.util.List;
+
+/**
+ * Response class for the system_information.json file.
+ * See https://github.com/NABSA/gbfs/blob/v1.0/gbfs.md#system_informationjson
+ */
+public class SystemInformation extends BaseGtfsResponse {
+    public SystemInformationData data;
+
+    /**
+     * See https://github.com/NABSA/gbfs/blob/v1.0/gbfs.md#system_informationjson
+     */
+    public class SystemInformationData {
+        public String system_id;
+        public String language;
+        public String name;
+        public String short_name;
+        public String operator;
+        public String url;
+        public String purchase_url;
+        public String start_date;
+        public String phone_number;
+        public String email;
+        public String timezone;
+        public String license_url;
+    }
+}

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/GBFSMappings/SystemInformation.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/GBFSMappings/SystemInformation.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.updater.vehicle_rental.GBFSMappings;
 
-import java.util.List;
-
 /**
  * Response class for the system_information.json file.
  * See https://github.com/NABSA/gbfs/blob/v1.0/gbfs.md#system_informationjson

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/GenericGbfsService.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/GenericGbfsService.java
@@ -8,6 +8,7 @@ import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.opentripplanner.analyst.UnsupportedGeometryException;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.vehicle_rental.RentalStation;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalRegion;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStation;
 import org.opentripplanner.updater.JsonConfigurable;
@@ -388,6 +389,12 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
             vehicleRentalStation.allowDropoff = station.num_docks_available > 0 &&
                 (station.is_installed == null || station.is_installed == 1) &&
                 (station.is_returning == null || station.is_returning == 1);
+
+            // set the last reported time
+            vehicleRentalStation.lastReportedEpochSeconds = RentalStation.getLastReportedTimeUsingFallbacks(
+                station.last_reported,
+                stationStatus.last_updated
+            );
         }
         stations.addAll(stationsByStationId.values());
         if (stations.size() > 0) {
@@ -417,6 +424,10 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
                 floatingVehicle.networks = Sets.newHashSet(networkName);
                 floatingVehicle.spacesAvailable = 0;
                 floatingVehicle.vehiclesAvailable = 1;
+                floatingVehicle.lastReportedEpochSeconds = RentalStation.getLastReportedTimeUsingFallbacks(
+                    bike.last_reported,
+                    floatingBikes.last_updated
+                );
 
                 stations.add(floatingVehicle);
             }

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/GenericGbfsService.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/GenericGbfsService.java
@@ -188,7 +188,7 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
      * Adds an error message to the list of errors and also logs the error message.
      */
     private void addError(RentalUpdaterError.Severity severity, Exception e, String message) {
-        message = String.format("%s (feed: %s)", message, networkName);
+        message = String.format("%s (network: %s)", message, networkName);
         errors.add(new RentalUpdaterError(severity, message));
         LOG.error(String.format("[severity: %s] %s", severity, message), e);
     }
@@ -240,7 +240,7 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
                     RentalUpdaterError.Severity.FEED_WIDE,
                     e,
                     "Failed to deserialize gbfs.json response: %s",
-                    e
+                    e.toString()
                 );
                 return;
             } finally {

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/GenericGbfsService.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/GenericGbfsService.java
@@ -12,10 +12,13 @@ import org.opentripplanner.routing.vehicle_rental.RentalStation;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalRegion;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStation;
 import org.opentripplanner.updater.JsonConfigurable;
+import org.opentripplanner.updater.RentalUpdaterError;
 import org.opentripplanner.updater.vehicle_rental.GBFSMappings.FreeBikeStatus;
 import org.opentripplanner.updater.vehicle_rental.GBFSMappings.GbfsResponse;
 import org.opentripplanner.updater.vehicle_rental.GBFSMappings.StationInformation;
 import org.opentripplanner.updater.vehicle_rental.GBFSMappings.StationStatus;
+import org.opentripplanner.updater.vehicle_rental.GBFSMappings.SystemInformation;
+import org.opentripplanner.util.DateUtils;
 import org.opentripplanner.util.NonLocalizedString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +55,9 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
     private List<VehicleRentalStation> stations;
     private boolean regionsLoadedFromConfig;
     private List<VehicleRentalRegion> regions;
+    private List<RentalUpdaterError> errors;
+    private SystemInformation.SystemInformationData systemInformationData;
+    private Date systemStartDate;
 
     public GenericGbfsService() {
         this(null, null, "en");
@@ -140,17 +146,8 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
         }
     }
 
-    @Override public boolean regionsUpdated() {
-        // return a one-time update if the regions were loaded from config
-        if (regionsLoadedFromConfig) {
-            regionsLoadedFromConfig = false;
-            return true;
-        }
-        return regionsUpdated;
-    }
-
-    @Override public boolean stationsUpdated() {
-        return vehiclesUpdated;
+    @Override public List<RentalUpdaterError> getErrors() {
+        return errors;
     }
 
     @Override public List<VehicleRentalStation> getStations() {
@@ -161,12 +158,44 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
         return regions;
     }
 
+    @Override public boolean regionsUpdated() {
+        // return a one-time update if the regions were loaded from config
+        if (regionsLoadedFromConfig) {
+            regionsLoadedFromConfig = false;
+            return true;
+        }
+        return regionsUpdated;
+    }
+
+    @Override public SystemInformation.SystemInformationData getSystemInformation() {
+        return systemInformationData;
+    }
+
+    /**
+     * Helper method for adding an error with a template String and associated values
+     */
+    private void addError(RentalUpdaterError.Severity severity, String template, Object... values) {
+        addError(severity, String.format(template, values));
+    }
+
+    /**
+     * Adds an erorr message to the list of errors and also logs the error message.
+     */
+    private void addError(RentalUpdaterError.Severity severity, String message) {
+        message = String.format("%s (feed: %s)", message, networkName);
+        errors.add(new RentalUpdaterError(severity, message));
+        LOG.error(String.format("[severity: %s] %s", severity, message));
+    }
+
     @Override
     public void update () {
         // reset update statuses and data
         vehiclesUpdated = false;
         regionsUpdated = false;
-        stations = new ArrayList<>();
+        stations = new LinkedList<>();
+        errors = new LinkedList<>();
+        systemInformationData = null;
+        systemStartDate = null;
 
         String systemInformationUrl = null;
         String stationInformationUrl = null;
@@ -201,7 +230,11 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
             try {
                 gbfsResponse = mapper.readValue(rootData, GbfsResponse.class);
             } catch (IOException e) {
-                LOG.error("failed to deserialize gbfs.json response: {}", e);
+                addError(
+                    RentalUpdaterError.Severity.FEED_WIDE,
+                    "Failed to deserialize gbfs.json response: %s",
+                    e
+                );
                 return;
             } finally {
                 try {
@@ -211,7 +244,7 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
                 }
             }
             if (gbfsResponse.data == null) {
-                LOG.error("failed to read gbfs.json, no data found");
+                addError(RentalUpdaterError.Severity.FEED_WIDE, "Failed to read gbfs.json, no data found");
                 return;
             }
 
@@ -219,7 +252,12 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
             // FIXME: the configured language always defaults to "en" in this current implementation.
             GbfsResponse.GbfsFeeds feeds = gbfsResponse.data.get(language);
             if (feeds == null) {
-                LOG.error("requested language ({}) not available in GBFS: {}", language, rootUrl);
+                addError(
+                    RentalUpdaterError.Severity.FEED_WIDE,
+                    "requested language (%s) not available in GBFS: %s",
+                    language,
+                    rootUrl
+                );
                 return;
             }
 
@@ -257,11 +295,11 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
             }
         }
 
-        // TODO: make the following methods asynchronous
         // get basic system information. Although this URL/file is technically required, don't fail fast if fetching
         // data from this service doesn't work for some reason.
         updateSystemInformation(systemInformationUrl);
 
+        // TODO: make the following methods asynchronous
         // get information related to docking stations
         updateDockedStationInformation(stationInformationUrl, stationStatusUrl);
 
@@ -284,35 +322,41 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
     }
 
     /**
-     * Update the system information URL
-     * @param url
+     * Update the system information URL.
      */
     private void updateSystemInformation(String url) {
         if (url == null) {
-            LOG.error("system_information URL is required, but none was found for feed: {}", networkName);
+            addError(
+                RentalUpdaterError.Severity.SYSTEM_INFORMATION,
+                "system_information URL is required, but none was found."
+            );
             return;
         }
-        InputStream data = fetchFromUrl(url, true);
+        SystemInformation data = fetchAndParseFromUrl(url, SystemInformation.class, true);
         if (data == null) {
-            LOG.error("failed to fetch required data from system_information URL for feed: {}", networkName);
+            addError(
+                RentalUpdaterError.Severity.SYSTEM_INFORMATION,
+                "failed to fetch or parse required data from system_information URL."
+            );
             return;
         }
-        // TODO consume data regarding system start date
-        try {
-            data.close();
-        } catch (IOException e) {
-            e.printStackTrace();
+        systemInformationData = data.data;
+    }
+
+    /**
+     * Only add and log an error if the config specifically notes that docking stations are expected in this feed.
+     */
+    private void addErrorIfDocksExpected(String message) {
+        if (hasDocks) {
+            addError(RentalUpdaterError.Severity.ALL_STATIONS, message);
         }
     }
 
     private void updateDockedStationInformation(String stationInformationUrl, String stationStatusUrl) {
         // get the station information
         if (stationInformationUrl == null) {
-            // this URL/file is not required unless the system uses docks. Only log a warning if the config specifically
-            // notes that docking stations are expected in this feed.
-            if (hasDocks) {
-                LOG.error("Conditionally required station_information URL is not defined for feed: {}", networkName);
-            }
+            // this URL/file is not required unless the system uses docks.
+            addErrorIfDocksExpected("Conditionally required station_information URL is not defined.");
 
             // There is no point in continuing without gps info on the station locations
             return;
@@ -324,6 +368,7 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
         );
         if (stationInfo == null) {
             // There is no point in continuing without gps info on the station locations
+            addErrorIfDocksExpected("Failed to fetched/parse station info.");
             return;
         }
 
@@ -338,18 +383,16 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
 
         // get status statuses
         if (stationStatusUrl == null) {
-            LOG.error("Station information found, but station status URL is not defined for feed: {}", networkName);
+            addError(
+                RentalUpdaterError.Severity.ALL_STATIONS,
+                "Station information found, but station status URL is not defined."
+            );
             return;
         }
         StationStatus stationStatus = fetchAndParseFromUrl(stationStatusUrl, StationStatus.class, hasDocks);
         if (stationStatus == null) {
-            if (hasDocks) {
-                // this file is required, so something went wrong.
-                LOG.error(
-                    "Failed to fetch and/or parse conditionally required data from station information for feed: {}",
-                    networkName
-                );
-            }
+            // this file is required, so something went wrong.
+            addErrorIfDocksExpected("Failed to fetch/parse station status.");
             // Don't process null station status info
             return;
         }
@@ -357,37 +400,36 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
         for (StationStatus.DockingStationStatusInformation station : stationStatus.data.stations) {
             VehicleRentalStation vehicleRentalStation = stationsByStationId.get(station.station_id);
             if (vehicleRentalStation == null) {
-                LOG.error(
-                    "Station with id: {} not found in station information data for feed: {}",
-                    station.station_id,
-                    networkName
+                addError(
+                    RentalUpdaterError.Severity.INDIVIDUAL_DOCKING_STATION,
+                    "Station with id: %s not found in station information data.",
+                    station.station_id
+                );
+                continue;
+            }
+            if (station.num_bikes_available == null) {
+                addError(
+                    RentalUpdaterError.Severity.INDIVIDUAL_DOCKING_STATION,
+                    "Station with id: %s missing required information on number of vehicles available.",
+                    station.station_id
+                );
+                continue;
+            }
+            if (station.num_docks_available == null) {
+                addError(
+                    RentalUpdaterError.Severity.INDIVIDUAL_DOCKING_STATION,
+                    "Station with id: %s missing required information on number of docks available.",
+                    station.station_id
                 );
                 continue;
             }
             vehicleRentalStation.spacesAvailable = station.num_docks_available;
             vehicleRentalStation.vehiclesAvailable = station.num_bikes_available;
-            if (station.num_bikes_available == null) {
-                LOG.error(
-                    "Station with id: {} missing required information on number of vehicles available within feed: {}",
-                    station.station_id,
-                    networkName
-                );
-                continue;
-            }
-            if (station.num_docks_available == null) {
-                LOG.error(
-                    "Station with id: {} missing required information on number of docks available within feed: {}",
-                    station.station_id,
-                    networkName
-                );
-                continue;
-            }
+
             // assume pickups and dropoffs are allowed if installed if optional data is not provided
-            vehicleRentalStation.allowPickup = station.num_bikes_available > 0 &&
-                (station.is_installed == null || station.is_installed == 1) &&
+            vehicleRentalStation.allowPickup = (station.is_installed == null || station.is_installed == 1) &&
                 (station.is_renting == null || station.is_renting == 1);
-            vehicleRentalStation.allowDropoff = station.num_docks_available > 0 &&
-                (station.is_installed == null || station.is_installed == 1) &&
+            vehicleRentalStation.allowDropoff = (station.is_installed == null || station.is_installed == 1) &&
                 (station.is_returning == null || station.is_returning == 1);
 
             // set the last reported time
@@ -397,14 +439,16 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
             );
         }
         stations.addAll(stationsByStationId.values());
-        if (stations.size() > 0) {
-            vehiclesUpdated = true;
-        }
+        vehiclesUpdated = true;
     }
 
     private void updateFreeFloatingVehicles(String freeBikeStatusUrl) {
         FreeBikeStatus floatingBikes = fetchAndParseFromUrl(freeBikeStatusUrl, FreeBikeStatus.class);
         if (floatingBikes == null) {
+            addError(
+                RentalUpdaterError.Severity.ALL_FLOATING_VEHICLES,
+                "Unable to fetch/parse floating vehicles."
+            );
             return;
         }
         for (FreeBikeStatus.FreeBike bike : floatingBikes.data.bikes) {
@@ -432,9 +476,7 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
                 stations.add(floatingVehicle);
             }
         }
-        if (stations.size() > 0) {
-            vehiclesUpdated = true;
-        }
+        vehiclesUpdated = true;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/GenericGbfsService.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/GenericGbfsService.java
@@ -173,17 +173,24 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
     /**
      * Helper method for adding an error with a template String and associated values
      */
+    private void addError(RentalUpdaterError.Severity severity, Exception e, String template, Object... values) {
+        addError(severity, e, String.format(template, values));
+    }
+
+    /**
+     * Helper method for adding an error with a template String and associated values
+     */
     private void addError(RentalUpdaterError.Severity severity, String template, Object... values) {
-        addError(severity, String.format(template, values));
+        addError(severity, null, String.format(template, values));
     }
 
     /**
      * Adds an error message to the list of errors and also logs the error message.
      */
-    private void addError(RentalUpdaterError.Severity severity, String message) {
+    private void addError(RentalUpdaterError.Severity severity, Exception e, String message) {
         message = String.format("%s (feed: %s)", message, networkName);
         errors.add(new RentalUpdaterError(severity, message));
-        LOG.error(String.format("[severity: %s] %s", severity, message));
+        LOG.error(String.format("[severity: %s] %s", severity, message), e);
     }
 
     @Override
@@ -231,6 +238,7 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
             } catch (IOException e) {
                 addError(
                     RentalUpdaterError.Severity.FEED_WIDE,
+                    e,
                     "Failed to deserialize gbfs.json response: %s",
                     e
                 );

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/GenericGbfsService.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/GenericGbfsService.java
@@ -179,7 +179,7 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
     }
 
     /**
-     * Adds an erorr message to the list of errors and also logs the error message.
+     * Adds an error message to the list of errors and also logs the error message.
      */
     private void addError(RentalUpdaterError.Severity severity, String message) {
         message = String.format("%s (feed: %s)", message, networkName);

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/GenericGbfsService.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/GenericGbfsService.java
@@ -18,7 +18,6 @@ import org.opentripplanner.updater.vehicle_rental.GBFSMappings.GbfsResponse;
 import org.opentripplanner.updater.vehicle_rental.GBFSMappings.StationInformation;
 import org.opentripplanner.updater.vehicle_rental.GBFSMappings.StationStatus;
 import org.opentripplanner.updater.vehicle_rental.GBFSMappings.SystemInformation;
-import org.opentripplanner.util.DateUtils;
 import org.opentripplanner.util.NonLocalizedString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/GenericGbfsService.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/GenericGbfsService.java
@@ -309,6 +309,20 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
 
         // TODO have NABSA make rental regions a part of their spec somehow. See https://github.com/NABSA/gbfs/issues/65
         updateRegions();
+
+        // Add a feed-wide error if there was a problem fetching both stations and floating vehicles
+        boolean errorFetchingStations = false;
+        boolean errorFetchingFloatingVehicles = false;
+        for (RentalUpdaterError error : errors) {
+            if (error.severity == RentalUpdaterError.Severity.ALL_STATIONS) {
+                errorFetchingStations = true;
+            } else if (error.severity == RentalUpdaterError.Severity.ALL_FLOATING_VEHICLES) {
+                errorFetchingFloatingVehicles = true;
+            }
+        }
+        if (errorFetchingStations && errorFetchingFloatingVehicles) {
+            addError(RentalUpdaterError.Severity.FEED_WIDE, "Both station and vehicle info not found!");
+        }
     }
 
     /**

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalDataSource.java
@@ -26,17 +26,17 @@ import java.util.List;
  */
 public interface VehicleRentalDataSource {
     /**
-     * @return a List of all errors that occurred during the most recent update.
+     * @return a list of all errors that occurred during the most recent update.
      */
     List<RentalUpdaterError> getErrors();
 
     /**
-     * @return a List of all currently known vehicle rental stations. The updater will use this to update the Graph.
+     * @return a list of all currently known vehicle rental stations. The updater will use this to update the Graph.
      */
     List<VehicleRentalStation> getStations();
 
     /**
-     * @return a List of all currently known vehicle rental regions. The updater will use this to update the Graph.
+     * @return a list of all currently known vehicle rental regions. The updater will use this to update the Graph.
      */
     List<VehicleRentalRegion> getRegions();
 

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalDataSource.java
@@ -15,6 +15,8 @@ package org.opentripplanner.updater.vehicle_rental;
 
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalRegion;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStation;
+import org.opentripplanner.updater.RentalUpdaterError;
+import org.opentripplanner.updater.vehicle_rental.GBFSMappings.SystemInformation;
 
 import java.util.List;
 
@@ -23,12 +25,10 @@ import java.util.List;
  * regions that can be updated over time.
  */
 public interface VehicleRentalDataSource {
-
-    /** Returns true if there might have been changes to the regions */
-    boolean regionsUpdated();
-
-    /** Returns true if there might have been changes to the stations */
-    boolean stationsUpdated();
+    /**
+     * @return a List of all errors that occurred during the most recent update.
+     */
+    List<RentalUpdaterError> getErrors();
 
     /**
      * @return a List of all currently known vehicle rental stations. The updater will use this to update the Graph.
@@ -39,6 +39,14 @@ public interface VehicleRentalDataSource {
      * @return a List of all currently known vehicle rental regions. The updater will use this to update the Graph.
      */
     List<VehicleRentalRegion> getRegions();
+
+    /** returns true if the regions have been updated since the last updated */
+    boolean regionsUpdated();
+
+    /**
+     * Return the System Information found during the most recent update.
+     */
+    SystemInformation.SystemInformationData getSystemInformation();
 
     // updates to the latest data
     void update();

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -172,7 +172,7 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
 
             // Apply stations to graph if a feed-wide error did not occur
             if (!feedWideError) {
-                /* add any new stations that have fresh-enough data and update vehicle counts for existing stations */
+                // add any new stations that have fresh-enough data and update vehicle counts for existing stations
                 for (VehicleRentalStation station : stations) {
                     if (!DateUtils.withinTimeToLive(station.lastReportedEpochSeconds, timeToLiveMinutes)) {
                         // skip station as it does not have fresh-enough data

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -30,8 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -76,13 +76,7 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
         source.update();
 
         // Create graph writer runnable to apply these stations and regions to the graph
-        updaterManager.execute(new VehicleRentalGraphWriterRunnable(
-            source.getErrors(),
-            source.getRegions(),
-            source.regionsUpdated(),
-            source.getStations(),
-            source.getSystemInformation()
-        ));
+        updaterManager.execute(new VehicleRentalGraphWriterRunnable(source));
     }
 
     @Override
@@ -137,18 +131,12 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
 
         private final GeometryFactory geometryFactory = new GeometryFactory();
 
-        public VehicleRentalGraphWriterRunnable(
-            List<RentalUpdaterError> errors,
-            List<VehicleRentalRegion> regions,
-            boolean regionsUpdated,
-            List<VehicleRentalStation> stations,
-            SystemInformation.SystemInformationData systemInformationData
-        ) {
-            this.errors = errors;
-            this.regions = regions;
-            this.regionsUpdated = regionsUpdated;
-            this.stations = stations;
-            this.systemInformationData = systemInformationData;
+        public VehicleRentalGraphWriterRunnable(VehicleRentalDataSource source) {
+            errors = source.getErrors();
+            regions = source.getRegions();
+            regionsUpdated = source.regionsUpdated();
+            stations = source.getStations();
+            systemInformationData = source.getSystemInformation();
         }
 
         @Override

--- a/src/main/java/org/opentripplanner/util/DateUtils.java
+++ b/src/main/java/org/opentripplanner/util/DateUtils.java
@@ -284,7 +284,7 @@ public class DateUtils implements DateConstants {
     }
 
     /**
-     * Returns false if the given epochSeconds is more than ttlMinutes in the past.
+     * Returns false if the given epochSeconds is more than timeToLiveMinutes in the past.
      */
     public static boolean withinTimeToLive (Long epochSeconds, int timeToLiveMinutes) {
         return (System.currentTimeMillis() / 1000 - epochSeconds) / 60 < timeToLiveMinutes;

--- a/src/main/java/org/opentripplanner/util/DateUtils.java
+++ b/src/main/java/org/opentripplanner/util/DateUtils.java
@@ -282,4 +282,11 @@ public class DateUtils implements DateConstants {
         else
             return System.currentTimeMillis() + (long)(relativeTimeoutSeconds * 1000.0);
     }
+
+    /**
+     * Returns false if the given epochSeconds is more than ttlMinutes in the past.
+     */
+    public static boolean withinTimeToLive (Long epochSeconds, int timeToLiveMinutes) {
+        return (System.currentTimeMillis() / 1000 - epochSeconds) / 60 < timeToLiveMinutes;
+    }
 }

--- a/src/test/java/org/opentripplanner/updater/car_rental/TestCar2GoCarRentalDataSource.java
+++ b/src/test/java/org/opentripplanner/updater/car_rental/TestCar2GoCarRentalDataSource.java
@@ -44,7 +44,7 @@ public class TestCar2GoCarRentalDataSource extends TestCase {
         car2GoCarRentalDataSource.configure(null, config);
 
         // update data source and consume vehicles json
-        assertTrue(car2GoCarRentalDataSource.updateStations());
+        car2GoCarRentalDataSource.update();
         List<CarRentalStation> rentalStations = car2GoCarRentalDataSource.getStations();
         assertEquals(3, rentalStations.size());
         for (CarRentalStation rentalStation : rentalStations) {
@@ -73,7 +73,7 @@ public class TestCar2GoCarRentalDataSource extends TestCase {
         Car2GoCarRentalDataSource car2GoCarRentalDataSource = new Car2GoCarRentalDataSource();
         car2GoCarRentalDataSource.configure(null, config);
 
-        assertTrue(car2GoCarRentalDataSource.updateRegions());
+        car2GoCarRentalDataSource.update();
         CarRentalRegion firstRegion = car2GoCarRentalDataSource.getRegions().get(0);
 
         // verify integrity of region, by checking if a particular point exists inside it

--- a/src/test/java/org/opentripplanner/updater/vehicle_rental/TestGenericGbfsService.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_rental/TestGenericGbfsService.java
@@ -44,7 +44,6 @@ public class TestGenericGbfsService extends TestCase {
 
         // update data source and consume vehicles json
         gbfsVehicleRentalDataSource.update();
-        assertTrue(gbfsVehicleRentalDataSource.stationsUpdated());
         List<VehicleRentalStation> rentalStations = gbfsVehicleRentalDataSource.getStations();
         assertEquals(4, rentalStations.size());
         for (VehicleRentalStation rentalStation : rentalStations) {


### PR DESCRIPTION
This PR mainly adds code to handle errors when fetching GBFS feeds. It classifies various errors by severity and will then display these errors in the plan API endpoint and also the vehicle rental API endpoint. Another thing this PR does is actually parse the system information data and also include that in the previously mentioned API endpoints. And since we're now tracking errors and handling them, this code also implements a TTL functionality that will automatically remove rental vehicles after they have outlived a user-defined TTL. This code is somewhat incomplete as it is only implemented fully for vehicle rentals (e-scooters). If this approach seems OK, it should also be implemented for car rentals and bike rentals to be consistent.