### PR TITLE
Fix issues with banning trip sequences and certain GBFS feeds

### DIFF
--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -191,8 +191,9 @@ public class GraphPathFinder {
                 if (tripIds.isEmpty()) {
                     // This path does not use transit (is entirely on-street). Do not repeatedly find the same one.
                     options.onlyTransitTrips = true;
+                } else {
+                    options.banTripSequencesInPath(path);
                 }
-                options.banTripSequencesInPath(path);
                 // Call-and-Ride trips should not use regular trip-banning, since call-and-ride trips can beused in
                 // multiple ways (e.g. from origin to destination, or from origin to a transfer stop.) Instead,
                 // after an itinerary which uses call-and-ride is found, reduce the allowable call-and-ride duration

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/GenericGbfsService.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/GenericGbfsService.java
@@ -217,6 +217,11 @@ public class GenericGbfsService implements VehicleRentalDataSource, JsonConfigur
         // See https://github.com/NABSA/gbfs/blob/master/gbfs.md#files
         InputStream rootData = fetchFromUrl(makeGbfsEndpointUrl("gbfs.json"));
 
+        // Some companies put their GBFS file at the root URL. If the rootData is null, try again from the root URL.
+        if (rootData == null) {
+            rootData = fetchFromUrl(rootUrl);
+        }
+
         // Check to see if data from the root url was able to be fetched. The GBFS.json file is not required.
         if (rootData == null) {
             // Root GBFS.json file not able to be fetched, set default endpoints.


### PR DESCRIPTION
This PR fixes two things:

1. Only trip sequences where there is at least one trip in a path are now banned. This will avoid ArrayIndexOutOfBoundsExceptions when other trips try to iterate through empty lists.
2. The vehicle rental GBFS fetcher will now retry to get the gbfs.json file at the root URL if the pattern rootURL/gbfs.json doesn't work.