### PR TITLE
Add ability to report errors to Bugsnag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -765,5 +765,11 @@
             <artifactId>bsf</artifactId>
             <version>2.4.0</version>
         </dependency>
+        <!-- Error reporting -->
+        <dependency>
+            <groupId>com.bugsnag</groupId>
+            <version>3.6.2</version>
+            <artifactId>bugsnag</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
+++ b/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.api.common;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.opentripplanner.standalone.BugsnagReporter;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -9,11 +8,11 @@ import javax.ws.rs.ext.Provider;
 
 @Provider
 public class OTPExceptionMapper implements ExceptionMapper<Exception> {
-    private static final Logger LOG = LoggerFactory.getLogger(OTPExceptionMapper.class);
 
     public Response toResponse(Exception ex) {
         // Show the exception in the server log
-        LOG.error("Unhandled exception", ex);
+        BugsnagReporter.reportErrorToBugsnag("Unhandled server exception", ex);
+
         // Return the short form message to the client
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                 .entity(ex.toString() + " " + ex.getMessage())

--- a/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
+++ b/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
@@ -10,7 +10,6 @@ import javax.ws.rs.ext.Provider;
 public class OTPExceptionMapper implements ExceptionMapper<Exception> {
 
     public Response toResponse(Exception ex) {
-        // Show the exception in the server log
         BugsnagReporter.reportErrorToBugsnag("Unhandled server exception", ex);
 
         // Return the short form message to the client

--- a/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
+++ b/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.api.common;
 
-import org.opentripplanner.standalone.BugsnagReporter;
+import org.opentripplanner.standalone.ErrorUtils;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -10,7 +10,7 @@ import javax.ws.rs.ext.Provider;
 public class OTPExceptionMapper implements ExceptionMapper<Exception> {
 
     public Response toResponse(Exception ex) {
-        BugsnagReporter.reportErrorToBugsnag("Unhandled server exception", ex);
+        ErrorUtils.reportErrorToBugsnag("Unhandled server exception", ex);
 
         // Return the short form message to the client
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR)

--- a/src/main/java/org/opentripplanner/api/model/error/PlannerError.java
+++ b/src/main/java/org/opentripplanner/api/model/error/PlannerError.java
@@ -4,7 +4,7 @@ import org.opentripplanner.api.common.LocationNotAccessible;
 import org.opentripplanner.api.common.Message;
 import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.error.*;
-import org.opentripplanner.standalone.BugsnagReporter;
+import org.opentripplanner.standalone.ErrorUtils;
 
 import java.util.HashMap;
 import java.util.List;
@@ -41,7 +41,7 @@ public class PlannerError {
         message = messages.get(e.getClass());
         if (message == null) {
             message = Message.SYSTEM_ERROR;
-            BugsnagReporter.reportErrorToBugsnag("Unhandled exception while planning trip", req, e);
+            ErrorUtils.reportErrorToBugsnag("Unhandled exception while planning trip", req, e);
         }
         this.setMsg(message);
         if (e instanceof VertexNotFoundException)

--- a/src/main/java/org/opentripplanner/api/model/error/PlannerError.java
+++ b/src/main/java/org/opentripplanner/api/model/error/PlannerError.java
@@ -2,9 +2,9 @@ package org.opentripplanner.api.model.error;
 
 import org.opentripplanner.api.common.LocationNotAccessible;
 import org.opentripplanner.api.common.Message;
+import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.error.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.opentripplanner.standalone.BugsnagReporter;
 
 import java.util.HashMap;
 import java.util.List;
@@ -12,8 +12,6 @@ import java.util.Map;
 
 /** This API response element represents an error in trip planning. */
 public class PlannerError {
-
-    private static final Logger LOG = LoggerFactory.getLogger(PlannerError.class);
     private static Map<Class<? extends Exception>, Message> messages;
     static {
         messages = new HashMap<Class<? extends Exception>, Message> ();
@@ -38,12 +36,12 @@ public class PlannerError {
         noPath = true;
     }
 
-    public PlannerError(Exception e) {
+    public PlannerError(RoutingRequest req, Exception e) {
         this();
         message = messages.get(e.getClass());
         if (message == null) {
-            LOG.error("exception planning trip: ", e);
             message = Message.SYSTEM_ERROR;
+            BugsnagReporter.reportErrorToBugsnag("Unhandled exception while planning trip", req, e);
         }
         this.setMsg(message);
         if (e instanceof VertexNotFoundException)

--- a/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
+++ b/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
@@ -82,7 +82,7 @@ public class PlannerResource extends RoutingResource {
             else response.setPlan(plan);
 
         } catch (Exception e) {
-            PlannerError error = new PlannerError(e);
+            PlannerError error = new PlannerError(request, e);
             if(!PlannerError.isPlanningError(e.getClass()))
                 LOG.warn("Error while planning path: ", e);
             response.setError(error);

--- a/src/main/java/org/opentripplanner/standalone/BugsnagReporter.java
+++ b/src/main/java/org/opentripplanner/standalone/BugsnagReporter.java
@@ -1,0 +1,77 @@
+package org.opentripplanner.standalone;
+
+import com.bugsnag.Bugsnag;
+import com.bugsnag.Report;
+import com.bugsnag.Severity;
+import org.opentripplanner.common.MavenVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Bugsnag util for reporting errors to the project defined by the Bugsnag project notifier API key.
+ *
+ * A Bugsnag project identifier key is unique to a Bugsnag project and allows errors to be saved against it. This key
+ * can be obtained by logging into Bugsnag (https://app.bugsnag.com), clicking on Projects (left side menu) and
+ * selecting the required project. Once selected, the notifier API key is presented.
+ */
+public class BugsnagReporter {
+    private static Bugsnag bugsnag;
+    private static final Logger LOG = LoggerFactory.getLogger(BugsnagReporter.class);
+
+    /**
+     * Initialize Bugsnag using the project notifier API key when the application is first loaded.
+     * @param params The parsed OTP command line parameters
+     */
+    public static void initializeBugsnagErrorReporting(CommandLineParameters params) {
+        if (params.bugsnagKey != null) {
+            bugsnag = new Bugsnag(params.bugsnagKey);
+            bugsnag.setAppVersion(MavenVersion.VERSION.getShortVersionString());
+            if (params.bugsnagReleaseStage != null) {
+                bugsnag.setReleaseStage(params.bugsnagReleaseStage);
+            }
+            if (params.bugsnagAppType != null) {
+                bugsnag.setAppType(params.bugsnagAppType);
+            }
+            LOG.info("Bugsnag reporting enabled.");
+        } else {
+            LOG.warn("Bugsnag project notifier API key not available. Bugsnag error reporting disabled.");
+        }
+    }
+
+    /**
+     * If Bugsnag has been configured, report error based on provided information.
+     */
+    public static boolean reportErrorToBugsnag(String message, Throwable throwable) {
+        return reportErrorToBugsnag(message, null, throwable);
+    }
+
+    /**
+     * If Bugsnag has been configured, report error based on provided information. Note: throwable must be non-null.
+     */
+    public static boolean reportErrorToBugsnag(String message, Object badEntity, Throwable throwable) {
+        // Log error to log output.
+        LOG.error(message, throwable);
+
+        // If bugsnag is disabled, make sure to report full error to otp-middleware logs.
+        if (bugsnag == null) {
+            LOG.warn("Bugsnag error reporting is disabled. Unable to report to Bugsnag this message: {} for this bad entity: {}",
+                message,
+                badEntity,
+                throwable);
+            return false;
+        }
+
+        // If no throwable provided, create a new UnknownError exception so that Bugsnag will accept the error report.
+        if (throwable == null) {
+            LOG.warn("No exception provided for this error report (message: {}). New UnknownError used instead.", message);
+            throwable = new UnknownError("Exception type is unknown! Please add exception where report method is called.");
+        }
+
+        // Finally, construct report and send to bugsnag.
+        Report report = bugsnag.buildReport(throwable);
+        report.setContext(message);
+        report.addToTab("debugging", "bad entity", badEntity != null ? badEntity.toString() : "N/A");
+        report.setSeverity(Severity.ERROR);
+        return bugsnag.notify(report);
+    }
+}

--- a/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
@@ -138,6 +138,20 @@ public class CommandLineParameters implements Cloneable {
     @Parameter(names = { "--enableScriptingWebService" }, description = "enable scripting through a web-service (Warning! Very unsafe for public facing servers)")
     boolean enableScriptingWebService = false;
 
+    @Parameter(names = {"--bugsnagKey"},
+        description = "A Bugsnag project notifier key that will be used to report unhandled exceptions and trip planning errors.")
+    public String bugsnagKey = null;
+
+    @Parameter(names = {"--bugsnagReleaseStage"},
+        description = "A Bugsang release stage to use when reporting errors."
+    )
+    public String bugsnagReleaseStage;
+
+    @Parameter(names = {"--bugsnagAppType"},
+        description = "A Bugsang app type to use when reporting errors."
+    )
+    public String bugsnagAppType;
+
     /** Set some convenience parameters based on other parameters' values. */
     public void infer() {
         server |= (inMemory || preFlight || port != null);

--- a/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
@@ -148,7 +148,7 @@ public class CommandLineParameters implements Cloneable {
     public String bugsnagReleaseStage;
 
     @Parameter(names = {"--bugsnagAppType"},
-        description = "A Bugsang app type to use when reporting errors."
+        description = "A Bugsnag app type to use when reporting errors."
     )
     public String bugsnagAppType;
 

--- a/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
@@ -143,7 +143,7 @@ public class CommandLineParameters implements Cloneable {
     public String bugsnagKey = null;
 
     @Parameter(names = {"--bugsnagReleaseStage"},
-        description = "A Bugsang release stage to use when reporting errors."
+        description = "A Bugsnag release stage to use when reporting errors."
     )
     public String bugsnagReleaseStage;
 
@@ -283,4 +283,3 @@ public class CommandLineParameters implements Cloneable {
         }
     }
 }
-

--- a/src/main/java/org/opentripplanner/standalone/ErrorUtils.java
+++ b/src/main/java/org/opentripplanner/standalone/ErrorUtils.java
@@ -8,15 +8,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Bugsnag util for reporting errors to the project defined by the Bugsnag project notifier API key.
+ * A util class for reporting errors to the project defined by the Bugsnag project notifier API key.
  *
  * A Bugsnag project identifier key is unique to a Bugsnag project and allows errors to be saved against it. This key
  * can be obtained by logging into Bugsnag (https://app.bugsnag.com), clicking on Projects (left side menu) and
  * selecting the required project. Once selected, the notifier API key is presented.
  */
-public class BugsnagReporter {
+public class ErrorUtils {
     private static Bugsnag bugsnag;
-    private static final Logger LOG = LoggerFactory.getLogger(BugsnagReporter.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ErrorUtils.class);
 
     /**
      * Initialize Bugsnag using the project notifier API key when the application is first loaded.
@@ -52,7 +52,7 @@ public class BugsnagReporter {
         // Log error to log output.
         LOG.error(message, throwable);
 
-        // If bugsnag is disabled, make sure to report full error to otp-middleware logs.
+        // If bugsnag is disabled, make sure to report log full error.
         if (bugsnag == null) {
             LOG.warn("Bugsnag error reporting is disabled. Unable to report to Bugsnag this message: {} for this bad entity: {}",
                 message,

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -68,6 +68,8 @@ public class OTPMain {
             System.exit(-1);
         }
 
+        BugsnagReporter.initializeBugsnagErrorReporting(params);
+
         OTPMain main = new OTPMain(params);
         if (!main.run()) {
             System.exit(-1);

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -68,7 +68,7 @@ public class OTPMain {
             System.exit(-1);
         }
 
-        BugsnagReporter.initializeBugsnagErrorReporting(params);
+        ErrorUtils.initializeBugsnagErrorReporting(params);
 
         OTPMain main = new OTPMain(params);
         if (!main.run()) {


### PR DESCRIPTION
This PR adds the ability to have OpenTripPlanner report errors to Bugsnag. It adds:

- Bugsnag dependency in pom.xml
- new command line parameters: `bugsnagAppType`, `bugsnagKey` and `bugsnagReleaseStage`.
- A Bugsang util class that:
  - Sets up Bugsnag with the appropriate command line parameters
  - Has common methods for reporting exceptions to Bugsnag
- Error reporting when a trip planning exception without a predefined exception type occurs
- Error reporting when an unhandled server request on any other resource occurs