### PR TITLE
Slope avoidance and slope accessibility score 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ _site/
 /otp
 /otp-batch-analyst
 *.DS_Store
+otp-ui

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -85,6 +85,15 @@ public abstract class RoutingResource {
     @QueryParam("wheelchair")
     protected Boolean wheelchair;
 
+    /**
+     * The maximum slope that a wheelchair user can traverse before the street will be penalized
+     * and the accessibility score lowered.
+     *
+     * Values go from 0 to 1, so 5 percent is 0.05.
+     */
+    @QueryParam("maxSlope")
+    protected Double maxSlope;
+
     /** The maximum distance (in meters) the user is willing to walk. Defaults to unlimited. */
     @QueryParam("maxWalkDistance")
     protected Double maxWalkDistance;
@@ -594,6 +603,9 @@ public abstract class RoutingResource {
 
         if (wheelchair != null)
             request.setWheelchairAccessible(wheelchair);
+
+        if (maxSlope!= null)
+            request.maxSlope = maxSlope;
 
         if (numItineraries != null)
             request.setNumItineraries(numItineraries);

--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -56,7 +56,6 @@ import org.opentripplanner.routing.edgetype.RentABikeOffEdge;
 import org.opentripplanner.routing.edgetype.RentABikeOnEdge;
 import org.opentripplanner.routing.edgetype.SimpleTransfer;
 import org.opentripplanner.routing.edgetype.StreetEdge;
-import org.opentripplanner.routing.edgetype.StreetWithElevationEdge;
 import org.opentripplanner.routing.edgetype.TimedTransferEdge;
 import org.opentripplanner.routing.edgetype.TransitBoardAlight;
 import org.opentripplanner.routing.edgetype.TripPattern;
@@ -292,14 +291,14 @@ public abstract class GraphPathToTripPlanConverter {
             }
             else if (currentLeg.mode.equals("WALK") && request.wheelchairAccessible) {
 
-                boolean exceedsMaxSlope = Arrays.stream(legStates)
+                boolean maxSlopeExceeded = Arrays.stream(legStates)
                         .map(State::getBackEdge)
                         .filter(Objects::nonNull)
                         .filter(StreetEdge.class::isInstance)
                         .map(StreetEdge.class::cast)
-                        .anyMatch(s -> s.getMaxSlope() > 7);
+                        .anyMatch(s -> s.getMaxSlope() > request.maxSlope);
 
-                if(exceedsMaxSlope) {
+                if(maxSlopeExceeded) {
                     currentLeg.accessibilityScore = 0f;
                 } else {
                     currentLeg.accessibilityScore = 1f;

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -166,17 +166,9 @@ public class RoutingRequest implements Cloneable, Serializable {
     public int noWheelchairAccessOnStreetReluctance = 15;
 
     /**
-     * Maximum slope in percent that will lead to a 100% accessibility score.
-     *
-     * Anything above will be severely penalised but if it ends up being picked anyway (because
-     * there are no better options) it will lead to a lowered accessibility score for the walk leg.
+     * Routing cost penalty for exceeding the maximum slope.
      */
-    public float wheelchairSoftMaxSlope = 7;
-
-    /**
-     * If the soft maximum slope is exceeded
-     */
-    public float wheelchairMaxSlopeExceededPenalty = 5;
+    public float wheelchairMaxSlopeExceededReluctance = 5;
 
     /** The maximum number of itineraries to return. */
     public int numItineraries = 3;

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -165,6 +165,19 @@ public class RoutingRequest implements Cloneable, Serializable {
      */
     public int noWheelchairAccessOnStreetReluctance = 15;
 
+    /**
+     * Maximum slope in percent that will lead to a 100% accessibility score.
+     *
+     * Anything above will be severely penalised but if it ends up being picked anyway (because
+     * there are no better options) it will lead to a lowered accessibility score for the walk leg.
+     */
+    public float wheelchairSoftMaxSlope = 7;
+
+    /**
+     * If the soft maximum slope is exceeded
+     */
+    public float wheelchairMaxSlopeExceededPenalty = 5;
+
     /** The maximum number of itineraries to return. */
     public int numItineraries = 3;
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -223,7 +223,7 @@ public class StreetEdge extends Edge implements Cloneable, WheelchairEdge {
     private double wheelchairSlopePenaltyMultiplier(RoutingRequest options) {
         if (options.wheelchairAccessible) {
             if (getMaxSlope() > options.maxSlope) {
-                double howMuchExceeded = getMaxSlope() - options.maxSlope;
+                double howMuchExceeded = (getMaxSlope() - options.maxSlope) * 100;
                 double reluctance = howMuchExceeded * options.wheelchairMaxSlopeExceededReluctance;
                 if(reluctance < 1) {
                     return 1;

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -215,22 +215,24 @@ public class StreetEdge extends Edge implements Cloneable, WheelchairEdge {
     }
 
     /**
-     * Checks if edge is accessible for wheelchair if needed according to tags or if slope is too big.
+     * Computes how much the weight should be increased when the max slope for wheelchair users
+     * is exceeded.
      *
-     * Then it checks if street can be traversed according to street permissions and start/end barriers.
-     * This is done with intersection of street and barrier permissions in {@link #canTraverseIncludingBarrier(TraverseMode)}
-     *
-     * @param options
-     * @param mode
-     * @return
+     * 1 means that the cost should stay the same, 2 that the cost should double and so on.
      */
-    private boolean canTraverse(RoutingRequest options, TraverseMode mode) {
+    private double wheelchairSlopePenaltyMultiplier(RoutingRequest options) {
         if (options.wheelchairAccessible) {
             if (getMaxSlope() > options.maxSlope) {
-                return false;
+                double howMuchExceeded = getMaxSlope() - options.maxSlope;
+                double reluctance = howMuchExceeded * options.wheelchairMaxSlopeExceededReluctance;
+                if(reluctance < 1) {
+                    return 1;
+                } else {
+                    return reluctance;
+                }
             }
         }
-        return canTraverseIncludingBarrier(mode);
+        return 1;
     }
 
     /**
@@ -244,7 +246,6 @@ public class StreetEdge extends Edge implements Cloneable, WheelchairEdge {
      *
      * If start/end isn't bollard it just checks the street permissions.
      *
-     * It is used in {@link #canTraverse(RoutingRequest, TraverseMode)}
      * @param mode
      * @return
      */
@@ -539,7 +540,7 @@ public class StreetEdge extends Edge implements Cloneable, WheelchairEdge {
                     // occur here. NOTE: if the edge is only traversable by walking, then the backMode should be set to
                     // walk
                     editorWithVehicleRental.setBackMode(
-                        canTraverse(options, TraverseMode.MICROMOBILITY)
+                        canTraverseIncludingBarrier(TraverseMode.MICROMOBILITY)
                             ? TraverseMode.MICROMOBILITY
                             : TraverseMode.WALK
                     );
@@ -584,7 +585,7 @@ public class StreetEdge extends Edge implements Cloneable, WheelchairEdge {
         walkingBike &= TraverseMode.WALK.equals(traverseMode);
 
         /* Check whether this street allows the current mode. If not and we are biking, attempt to walk the bike. */
-        if (!canTraverse(options, traverseMode)) {
+        if (!canTraverseIncludingBarrier(traverseMode)) {
             if (traverseMode == TraverseMode.BICYCLE || traverseMode == TraverseMode.MICROMOBILITY) {
                 return doTraverse(s0, options.bikeWalkingOptions, TraverseMode.WALK);
             }
@@ -599,6 +600,7 @@ public class StreetEdge extends Edge implements Cloneable, WheelchairEdge {
         // TODO(flamholz): factor out this bike, wheelchair and walking specific logic to somewhere central.
         if (options.wheelchairAccessible) {
             weight = getSlopeSpeedEffectiveLength() / speed;
+            weight *= wheelchairSlopePenaltyMultiplier(options);
         } else if (traverseMode.equals(TraverseMode.BICYCLE)) {
             time = getSlopeSpeedEffectiveLength() / speed;
             switch (options.optimize) {

--- a/src/test/java/org/opentripplanner/ConstantsForTests.java
+++ b/src/test/java/org/opentripplanner/ConstantsForTests.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.URLDecoder;
 
 import org.opentripplanner.graph_builder.module.GraphBuilderModuleSummary;
+import org.opentripplanner.graph_builder.services.DefaultStreetEdgeFactory;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.graph_builder.module.DirectTransferGenerator;
 import org.opentripplanner.graph_builder.module.StreetLinkerModule;
@@ -113,6 +114,9 @@ public class ConstantsForTests {
             Graph g = new Graph();
             OpenStreetMapModule loader = new OpenStreetMapModule();
             loader.setDefaultWayPropertySetSource(new DefaultWayPropertySetSource());
+            DefaultStreetEdgeFactory streetEdgeFactory = new DefaultStreetEdgeFactory();
+            streetEdgeFactory.useElevationData = true;
+            loader.edgeFactory = streetEdgeFactory;
             AnyFileBasedOpenStreetMapProviderImpl provider = new AnyFileBasedOpenStreetMapProviderImpl();
 
             File file = new File(

--- a/src/test/java/org/opentripplanner/routing/core/AccessibilityRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/AccessibilityRoutingTest.java
@@ -236,24 +236,28 @@ public class AccessibilityRoutingTest {
 
     @Test
     public void slopeAccessibilityScore() {
+        double length = 650.0;
+        Coordinate[] profile = new Coordinate[] {
+                new Coordinate(0, 0), // slope = 0.1
+                new Coordinate(length / 2, length / 20.0),
+                new Coordinate(length, 0) // slope = -0.1
+        };
+        PackedCoordinateSequence elev = new PackedCoordinateSequence.Double(profile);
+
         Envelope e = new Envelope(new Coordinate(-84.36795, 33.75665));
-
-        PackedCoordinateSequence coordinates53 = new PackedCoordinateSequence.Double(
-                new double[]{90, 90, 180, 90}, 2);
-
         e.expandBy(0.001);
         graph.streetIndex.getEdgesForEnvelope(e).stream()
                 .filter(StreetWithElevationEdge.class::isInstance)
                 .map(StreetWithElevationEdge.class::cast)
                 .filter(s -> s.getName().startsWith("Old Wheat St"))
-                .forEach(s -> s.setElevationProfile(coordinates53, false));
+                .forEach(s -> s.setElevationProfile(elev, false));
 
         GenericLocation start = new GenericLocation(33.75561, -84.36798);
         GenericLocation end = new GenericLocation(33.75573, -84.36701);
         Itinerary i = getTripPlan(start, end, r -> r.setMode(TraverseMode.WALK)).itinerary.get(0);
         Leg leg = i.legs.get(0);
         assertEquals("WALK", leg.mode);
-        assertThatPolylinesAreEqual("sz_mE`v}aO?@?L?|AAzAM?A?G@SA[?I?E?C?E?oDCG?E?A?U?[?I??_@iAA@cAM?@o@?O", leg.legGeometry.getPoints());
+        assertThatPolylinesAreEqual("q{_mE|b}aOS?SACU?AeCmDr@@dBD??", leg.legGeometry.getPoints());
 
     }
 

--- a/src/test/java/org/opentripplanner/routing/core/AccessibilityRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/AccessibilityRoutingTest.java
@@ -4,19 +4,28 @@ package org.opentripplanner.routing.core;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.PolylineAssert.assertThatPolylinesAreEqual;
 
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.api.model.Itinerary;
 import org.opentripplanner.api.model.Leg;
 import org.opentripplanner.api.model.TripPlan;
 import org.opentripplanner.api.resource.GraphPathToTripPlanConverter;
+import org.opentripplanner.common.geometry.PackedCoordinateSequence;
 import org.opentripplanner.common.model.GenericLocation;
+import org.opentripplanner.graph_builder.module.ned.ElevationModule;
+import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.edgetype.StreetWithElevationEdge;
+import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.GraphPathFinder;
 import org.opentripplanner.routing.spt.GraphPath;
@@ -223,6 +232,29 @@ public class AccessibilityRoutingTest {
         assertEquals("WALK", leg.mode);
         assertEquals(0.5f, leg.accessibilityScore);
         assertThatPolylinesAreEqual("sz_mE`v}aO?@M?cA?}A?uFCM??L?R", leg.legGeometry.getPoints());
+    }
+
+    @Test
+    public void slopeAccessibilityScore() {
+        Envelope e = new Envelope(new Coordinate(-84.36795, 33.75665));
+
+        e.expandBy(0.001);
+        List<StreetWithElevationEdge> edges = graph.streetIndex.getEdgesForEnvelope(e).stream()
+                .filter(StreetWithElevationEdge.class::isInstance)
+                .map(StreetWithElevationEdge.class::cast)
+                .filter(s -> s.getName().startsWith("Old Wheat St"))
+                .collect(Collectors.toList());
+
+        System.out.println(edges);
+        assertTrue(edges.size() > 1);
+
+        GenericLocation start = new GenericLocation(33.75561, -84.36798);
+        GenericLocation end = new GenericLocation(33.75573, -84.36701);
+        Itinerary i = getTripPlan(start, end, r -> r.setMode(TraverseMode.WALK)).itinerary.get(0);
+        Leg leg = i.legs.get(0);
+        assertEquals("WALK", leg.mode);
+        assertThatPolylinesAreEqual("sz_mE`v}aO?@?L?|AAzAM?A?G@SA[?I?E?C?E?oDCG?E?A?U?[?I??_@iAA@cAM?@o@?O", leg.legGeometry.getPoints());
+
     }
 
     @Test

--- a/src/test/java/org/opentripplanner/routing/core/AccessibilityRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/AccessibilityRoutingTest.java
@@ -238,15 +238,15 @@ public class AccessibilityRoutingTest {
     public void slopeAccessibilityScore() {
         Envelope e = new Envelope(new Coordinate(-84.36795, 33.75665));
 
+        PackedCoordinateSequence coordinates53 = new PackedCoordinateSequence.Double(
+                new double[]{90, 90, 180, 90}, 2);
+
         e.expandBy(0.001);
-        List<StreetWithElevationEdge> edges = graph.streetIndex.getEdgesForEnvelope(e).stream()
+        graph.streetIndex.getEdgesForEnvelope(e).stream()
                 .filter(StreetWithElevationEdge.class::isInstance)
                 .map(StreetWithElevationEdge.class::cast)
                 .filter(s -> s.getName().startsWith("Old Wheat St"))
-                .collect(Collectors.toList());
-
-        System.out.println(edges);
-        assertTrue(edges.size() > 1);
+                .forEach(s -> s.setElevationProfile(coordinates53, false));
 
         GenericLocation start = new GenericLocation(33.75561, -84.36798);
         GenericLocation end = new GenericLocation(33.75573, -84.36701);

--- a/src/test/java/org/opentripplanner/routing/core/AccessibilityRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/AccessibilityRoutingTest.java
@@ -223,7 +223,7 @@ public class AccessibilityRoutingTest {
         assertEquals("WALK", leg.mode);
         assertThatPolylinesAreEqual("sz_mE`v}aO?@?L?|AAzAM?A?G@SA[?I?E?C?E?oDCG?E?A?U?[?I??_@iAA@cAM?@o@?O", leg.legGeometry.getPoints());
 
-        // if we reduce the reduce the reluctance for wheelchair-inaccessible streets we get a route that uses
+        // if we reduce the reluctance for wheelchair-inaccessible streets we get a route that uses
         // Hogue Street Northeast
         i = getTripPlan(start, end, r -> {
             r.setMode(TraverseMode.WALK);
@@ -247,8 +247,12 @@ public class AccessibilityRoutingTest {
         PackedCoordinateSequence elev = new PackedCoordinateSequence.Double(profile);
 
         SlopeCosts costs = ElevationUtils.getSlopeCosts(elev, false);
+
+        // we check that we really are going to set a 4 % slope
         assertEquals(0.04, costs.maxSlope);
 
+        // here we get Old Wheat St (https://www.openstreetmap.org/way/9270835)
+        // and set an artificial slope so we can test the feature
         Envelope e = new Envelope(new Coordinate(-84.36795, 33.75665));
         e.expandBy(0.001);
         graph.streetIndex.getEdgesForEnvelope(e).stream()


### PR DESCRIPTION
This PR implements part 2a of the [accessibility routing document](https://docs.google.com/document/d/1g10T4HVGGxSMCSO5IGaMS7aTLWPSCwj1a-rYSozT6Co/edit#).

- it allows you to traverse streets which are steeper than your configured `maxSlope` (this parameter already existed)
- computes the walking leg accessibility score consiting of two parts:
  - whether there were any wheelchair-inaccessible streets on the leg
  - how much you exceeded the maximum slope
  - if both are good then you get a score of 1. if not it quickly degrades to 0.

## Testing

Unit tests were added.