### PR TITLE
Hotfix: convert 'elevationGained' and 'elevationLost' to Integer

### DIFF
--- a/src/main/java/org/opentripplanner/api/model/Itinerary.java
+++ b/src/main/java/org/opentripplanner/api/model/Itinerary.java
@@ -56,12 +56,12 @@ public class Itinerary {
      * a trip that went from the top of Mount Everest straight down to sea level, then back up K2,
      * then back down again would have an elevationLost of Everest + K2.
      */
-    public Double elevationLost = 0.0;
+    public Integer elevationLost = 0;
     /**
      * How much elevation is gained, in total, over the course of the trip, in meters. See
      * elevationLost.
      */
-    public Double elevationGained = 0.0;
+    public Integer elevationGained = 0;
 
     /**
      * The number of transfers this trip has.

--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -795,9 +795,9 @@ public abstract class GraphPathToTripPlanConverter {
                 double change = coordinates.getOrdinate(i + 1, 1) - coordinates.getOrdinate(i, 1);
 
                 if (change > 0) {
-                    itinerary.elevationGained += change;
+                    itinerary.elevationGained += (int) change;
                 } else if (change < 0) {
-                    itinerary.elevationLost -= change;
+                    itinerary.elevationLost -= (int) change;
                 }
             }
         }

--- a/src/test/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverterTest.java
+++ b/src/test/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverterTest.java
@@ -1009,11 +1009,11 @@ public class GraphPathToTripPlanConverterTest {
 
         assertFalse(itinerary.walkLimitExceeded);
 
-        assertEquals(10.0, itinerary.elevationLost, 0.0);
+        assertEquals(9, itinerary.elevationLost, 0.0);
         if (type == Type.FORWARD || type == Type.BACKWARD) {
-            assertEquals(16.0, itinerary.elevationGained, 0.0);
+            assertEquals(14.0, itinerary.elevationGained, 0.0);
         } else if (type == Type.ONBOARD) {
-            assertEquals(6.1, itinerary.elevationGained, 0.0);
+            assertEquals(5, itinerary.elevationGained, 0.0);
         }
 
         assertEquals(1, itinerary.transfers.intValue());


### PR DESCRIPTION
The mobile team has reported that their parser expects `elevationGained` and `elevationLost` to be Integers not Doubles.

This PR changes the type of those variables.