### PR TITLE
Orca fare service fixes, Link+Sounder fare calculation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,12 +259,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.21.0</version>
+                <version>3.0.0-M5</version>
                 <configuration>
-                    <argLine>-Xmx2G</argLine>
+                    <argLine>-Xmx4G</argLine>
                     <argLine>-Dfile.encoding=UTF-8</argLine>
                     <!-- Jenkins needs XML test reports to determine whether the build is stable. -->
                     <disableXmlReport>false</disableXmlReport>
+                    <forkCount>2</forkCount>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
@@ -59,15 +59,7 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
     public boolean IS_TEST;
     public static final float DEFAULT_TEST_RIDE_PRICE = 3.49f;
 
-    public OrcaFareServiceImpl(Collection<FareRuleSet> regularFareRules) {
-        addFareRules(Fare.FareType.regular, regularFareRules);
-        addFareRules(Fare.FareType.senior, regularFareRules);
-        addFareRules(Fare.FareType.youth, regularFareRules);
-        addFareRules(Fare.FareType.electronicRegular, regularFareRules);
-        addFareRules(Fare.FareType.electronicYouth, regularFareRules);
-        addFareRules(Fare.FareType.electronicSpecial, regularFareRules);
-        addFareRules(Fare.FareType.electronicSenior, regularFareRules);
-
+    static {
         classificationStrategy.put(
             COMM_TRANS_AGENCY_ID,
             routeData -> {
@@ -161,6 +153,16 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
             "Southworth-VashonIsland",
             ImmutableMap.of(Fare.FareType.regular, 5.95f, Fare.FareType.youth, 2.95f, Fare.FareType.senior, 2.95f)
         );
+    }
+
+    public OrcaFareServiceImpl(Collection<FareRuleSet> regularFareRules) {
+        addFareRules(Fare.FareType.regular, regularFareRules);
+        addFareRules(Fare.FareType.senior, regularFareRules);
+        addFareRules(Fare.FareType.youth, regularFareRules);
+        addFareRules(Fare.FareType.electronicRegular, regularFareRules);
+        addFareRules(Fare.FareType.electronicYouth, regularFareRules);
+        addFareRules(Fare.FareType.electronicSpecial, regularFareRules);
+        addFareRules(Fare.FareType.electronicSenior, regularFareRules);
     }
 
     /**
@@ -369,7 +371,11 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
             if (hasFreeTransfers(fareType, rideType) && inFreeTransferWindow) {
                 // If using Orca (free transfers), the total fare should be equivalent to the
                 // most expensive leg of the journey.
-                orcaFareDiscount = Float.max(orcaFareDiscount, legFare);
+                // If the new fare is more than the current ORCA amount, the transfer is extended.
+                if (legFare > orcaFareDiscount) {
+                    freeTransferStartTime = ride.startTime;
+                    orcaFareDiscount = legFare;
+                }
            } else if (usesOrca(fareType) && !inFreeTransferWindow) {
                 // If using Orca and outside of the free transfer window, add the cumulative Orca fare (the maximum leg 
                 // fare encountered within the free transfer window).

--- a/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
@@ -471,7 +471,8 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
      * A free transfer can be applied if using Orca and the transit agency permits free transfers.
      */
     private boolean hasFreeTransfers(Fare.FareType fareType, RideType rideType) {
-        return permitsFreeTransfers(rideType) && usesOrca(fareType);
+        // King County Metro allows transfers on cash fare
+        return (permitsFreeTransfers(rideType) && usesOrca(fareType)) || (rideType == RideType.KC_METRO && !usesOrca(fareType));
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
@@ -92,7 +92,7 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
                     if(routeId >= 500 && routeId < 600) {
                         return RideType.SOUND_TRANSIT_BUS;
                     }
-                } catch(NumberFormatException ignored) {}
+                } catch(NumberFormatException ignored) {} // Lettered routes exist, are not an error.
                 if (routeData.getType() == ROUTE_TYPE_FERRY &&
                         routeData.getLongName().contains("Water Taxi: West Seattle")) {
                     return RideType.KC_WATER_TAXI_WEST_SEATTLE;
@@ -219,12 +219,21 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
                 rideType = RideType.KITSAP_TRANSIT_FAST_FERRY_WESTBOUND;
             }
         } else if (rideType == RideType.SOUND_TRANSIT &&
-            routeData.getShortName().equalsIgnoreCase("1-Line")
+            routeData.getShortName()
+                .replaceAll("-", "")
+                .replaceAll(" ", "")
+                .equalsIgnoreCase("1Line")
         ) {
             rideType = RideType.SOUND_TRANSIT_LINK;
         } else if (rideType == RideType.SOUND_TRANSIT && (
-                routeData.getShortName().equalsIgnoreCase("S Line") ||
-                routeData.getShortName().equalsIgnoreCase("N Line")
+                routeData.getShortName()
+                    .replaceAll("-", "")
+                    .replaceAll(" ", "")
+                    .equalsIgnoreCase("SLine") ||
+                routeData.getShortName()
+                    .replaceAll("-", "")
+                    .replaceAll(" ", "")
+                    .equalsIgnoreCase("NLine")
             )
         ) {
             rideType = RideType.SOUND_TRANSIT_SOUNDER;

--- a/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
@@ -158,11 +158,8 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
             "Southworth-VashonIsland",
             ImmutableMap.of(Fare.FareType.regular, 5.95f, Fare.FareType.youth, 2.95f, Fare.FareType.senior, 2.95f)
         );
-        // Section for SoundTransit Link Fares
-        soundTransitLinkFares.put(
-            "int'l dist/chinatown-roosevelt",
-            ImmutableMap.of(Fare.FareType.electronicRegular, 2.50f)
-        );
+
+        SoundTransitLinkFares.populateLinkFares(soundTransitLinkFares);
     }
 
     public OrcaFareServiceImpl(Collection<FareRuleSet> regularFareRules) {
@@ -251,8 +248,14 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
      *  Calculate the correct Link fare from a "ride" including start and end stations.
      */
     private float getSoundTransitLinkFare(Ride ride, Fare.FareType fareType, float defaultFare) {
-        String start = ride.firstStop.getName().replaceAll(" Station", "").toLowerCase();
-        String end = ride.lastStop.getName().replaceAll(" Station", "").toLowerCase();
+        String start = ride.firstStop.getName()
+            .replaceAll(" Station", "")
+            .replaceAll(" ", "")
+            .toLowerCase();
+        String end = ride.lastStop.getName()
+            .replaceAll(" Station", "")
+            .replaceAll(" ", "")
+            .toLowerCase();
         // Fares are the same no matter the order of the stations
         // Therefore, the fares DB only contains each station pair once
         // If no match is found, try the reversed order
@@ -276,6 +279,7 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
             case KITSAP_TRANSIT: return 1.00f;
             case KC_METRO:
             case SOUND_TRANSIT:
+            case SOUND_TRANSIT_LINK:
             case EVERETT_TRANSIT:
             case SEATTLE_STREET_CAR:
                 return 1.50f;
@@ -306,6 +310,7 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
             case KC_WATER_TAXI_WEST_SEATTLE: return 2.50f;
             case KC_METRO:
             case SOUND_TRANSIT:
+            case SOUND_TRANSIT_LINK:
                 return 1.00f;
             case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND:
                 return fareType.equals(Fare.FareType.electronicSenior) ? 5.00f : 10.00f;
@@ -334,6 +339,7 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
             case KC_WATER_TAXI_WEST_SEATTLE: return 3.75f;
             case KC_METRO:
             case SOUND_TRANSIT:
+            case SOUND_TRANSIT_LINK:
             case EVERETT_TRANSIT:
             case SEATTLE_STREET_CAR: return 1.50f;
             case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND:
@@ -371,6 +377,14 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
             return DEFAULT_TEST_RIDE_PRICE;
         }
         return calculateCost(fareType, Lists.newArrayList(ride), fareRules);
+    }
+
+    public boolean populateFare(Fare fare,
+                                Currency currency,
+                                Fare.FareType fareType,
+                                List<Ride> rides
+    ) {
+        return populateFare(fare, currency, fareType, rides, this.fareRulesPerType.get(fareType));
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
@@ -492,7 +492,7 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
             }
         }
         cost += orcaFareDiscount;
-        if (cost < Float.POSITIVE_INFINITY) {
+        if (cost < Float.POSITIVE_INFINITY && cost > 0) {
             fare.addFare(fareType, getMoney(currency, cost));
         }
         return cost > 0 && cost < Float.POSITIVE_INFINITY;

--- a/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
@@ -379,14 +379,6 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
         return calculateCost(fareType, Lists.newArrayList(ride), fareRules);
     }
 
-    public boolean populateFare(Fare fare,
-                                Currency currency,
-                                Fare.FareType fareType,
-                                List<Ride> rides
-    ) {
-        return populateFare(fare, currency, fareType, rides, this.fareRulesPerType.get(fareType));
-    }
-
     /**
      * Calculate the cost of a journey. Where free transfers are not permitted the cash price is used. If free transfers
      * are applicable, the most expensive discount fare across all legs is added to the final cumulative price.

--- a/src/main/java/org/opentripplanner/routing/impl/Ride.java
+++ b/src/main/java/org/opentripplanner/routing/impl/Ride.java
@@ -34,9 +34,9 @@ public class Ride {
     // it can be used differently in custom fare services
     Object classifier;
 
-    Stop firstStop;
+    public Stop firstStop;
 
-    Stop lastStop;
+    public Stop lastStop;
 
     public Ride() {
         zones = new HashSet<>();

--- a/src/main/java/org/opentripplanner/routing/impl/SoundTransitLinkFares.java
+++ b/src/main/java/org/opentripplanner/routing/impl/SoundTransitLinkFares.java
@@ -5,6 +5,12 @@ import org.opentripplanner.routing.core.Fare;
 
 import java.util.Map;
 
+/**
+ * Class used to store all the fares for Link light rail.
+ * Data comes from a Python script that parses SoundTransit's website.
+ * A matrix or CSV parser would be a better approach to storing this data,
+ * but a refactor is unneeded given the proximity of GTFS Fares V2 which will render this redundant.
+ */
 public class SoundTransitLinkFares {
     public static void populateLinkFares(Map<String, Map<Fare.FareType, Float>> linkLightRailFares) {
 

--- a/src/main/java/org/opentripplanner/routing/impl/SoundTransitLinkFares.java
+++ b/src/main/java/org/opentripplanner/routing/impl/SoundTransitLinkFares.java
@@ -1,0 +1,1049 @@
+package org.opentripplanner.routing.impl;
+
+import com.google.common.collect.ImmutableMap;
+import org.opentripplanner.routing.core.Fare;
+
+import java.util.Map;
+
+public class SoundTransitLinkFares {
+    public static void populateLinkFares(Map<String, Map<Fare.FareType, Float>> linkLightRailFares) {
+
+        linkLightRailFares.put(
+            "northgate-roosevelt",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "northgate-udistrict",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "northgate-univofwashington",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "northgate-capitolhill",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "northgate-stadium",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "northgate-sodo",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "northgate-beaconhill",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "northgate-mountbaker",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "northgate-columbiacity",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "northgate-othello",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "northgate-rainierbeach",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "northgate-tukwilaint'lblvd",
+            ImmutableMap.of(Fare.FareType.regular, 3.25f, Fare.FareType.electronicRegular, 3.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "northgate-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 3.5f, Fare.FareType.electronicRegular, 3.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "northgate-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 3.5f, Fare.FareType.electronicRegular, 3.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-udistrict",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-univofwashington",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-capitolhill",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-stadium",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-sodo",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-beaconhill",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-mountbaker",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-columbiacity",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-othello",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-rainierbeach",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-tukwilaint'lblvd",
+            ImmutableMap.of(Fare.FareType.regular, 3.25f, Fare.FareType.electronicRegular, 3.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 3.25f, Fare.FareType.electronicRegular, 3.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 3.25f, Fare.FareType.electronicRegular, 3.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "udistrict-univofwashington",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "udistrict-capitolhill",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "udistrict-stadium",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "udistrict-sodo",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "udistrict-beaconhill",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "udistrict-mountbaker",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "udistrict-columbiacity",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "udistrict-othello",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "udistrict-rainierbeach",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "udistrict-tukwilaint'lblvd",
+            ImmutableMap.of(Fare.FareType.regular, 3.25f, Fare.FareType.electronicRegular, 3.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "udistrict-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 3.25f, Fare.FareType.electronicRegular, 3.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "udistrict-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 3.25f, Fare.FareType.electronicRegular, 3.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "univofwashington-capitolhill",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "univofwashington-stadium",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "univofwashington-sodo",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "univofwashington-beaconhill",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "univofwashington-mountbaker",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "univofwashington-columbiacity",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "univofwashington-othello",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "univofwashington-rainierbeach",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "univofwashington-tukwilaint'lblvd",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "univofwashington-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 3.25f, Fare.FareType.electronicRegular, 3.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "univofwashington-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 3.25f, Fare.FareType.electronicRegular, 3.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "capitolhill-stadium",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "capitolhill-sodo",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "capitolhill-beaconhill",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "capitolhill-mountbaker",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "capitolhill-columbiacity",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "capitolhill-othello",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "capitolhill-rainierbeach",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "capitolhill-tukwilaint'lblvd",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "capitolhill-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "capitolhill-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "stadium-beaconhill",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "stadium-mountbaker",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "stadium-columbiacity",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "stadium-othello",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "stadium-rainierbeach",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "stadium-tukwilaint'lblvd",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "stadium-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "stadium-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "sodo-roosevelt",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "sodo-stadium",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "sodo-mountbaker",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "sodo-columbiacity",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "sodo-othello",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "sodo-rainierbeach",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "sodo-tukwilaint'lblvd",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "sodo-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "sodo-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "beaconhill-sodo",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "beaconhill-columbiacity",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "beaconhill-othello",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "beaconhill-rainierbeach",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "beaconhill-tukwilaint'lblvd",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "beaconhill-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "beaconhill-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "mountbaker-beaconhill",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "mountbaker-othello",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "mountbaker-rainierbeach",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "mountbaker-tukwilaint'lblvd",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "mountbaker-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "mountbaker-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "columbiacity-mountbaker",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "columbiacity-rainierbeach",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "columbiacity-tukwilaint'lblvd",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "columbiacity-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "columbiacity-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "othello-columbiacity",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "othello-tukwilaint'lblvd",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "othello-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "othello-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "rainierbeach-othello",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "rainierbeach-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "rainierbeach-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "tukwilaint'lblvd-rainierbeach",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "tukwilaint'lblvd-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "seatac/airport-tukwilaint'lblvd",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "anglelake-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "northgate-universityst",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "northgate-pioneersquare",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "northgate-int'ldist/chinatown",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-westlake",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-universityst",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-pioneersquare",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "roosevelt-int'ldist/chinatown",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "udistrict-westlake",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "udistrict-universityst",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "udistrict-pioneersquare",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "udistrict-int'ldist/chinatown",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "univofwashington-westlake",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "univofwashington-universityst",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "univofwashington-pioneersquare",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "univofwashington-int'ldist/chinatown",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "capitolhill-westlake",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "capitolhill-universityst",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "capitolhill-pioneersquare",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "capitolhill-int'ldist/chinatown",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "westlake-northgate",
+            ImmutableMap.of(Fare.FareType.regular, 2.75f, Fare.FareType.electronicRegular, 2.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "westlake-westlake",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "westlake-universityst",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "westlake-pioneersquare",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "westlake-int'ldist/chinatown",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "universityst-pioneersquare",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "universityst-int'ldist/chinatown",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "pioneersquare-int'ldist/chinatown",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "universityst-stadium",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "pioneersquare-stadium",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "int'ldist/chinatown-stadium",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "westlake-sodo",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "universityst-sodo",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "pioneersquare-sodo",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "int'ldist/chinatown-sodo",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "westlake-beaconhill",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "universityst-beaconhill",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "pioneersquare-beaconhill",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "int'ldist/chinatown-beaconhill",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "westlake-mountbaker",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "universityst-mountbaker",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "pioneersquare-mountbaker",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "int'ldist/chinatown-mountbaker",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "westlake-columbiacity",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "universityst-columbiacity",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "pioneersquare-columbiacity",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "int'ldist/chinatown-columbiacity",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "westlake-othello",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "universityst-othello",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "pioneersquare-othello",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "int'ldist/chinatown-othello",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "westlake-rainierbeach",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "universityst-rainierbeach",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "pioneersquare-rainierbeach",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "int'ldist/chinatown-rainierbeach",
+            ImmutableMap.of(Fare.FareType.regular, 2.5f, Fare.FareType.electronicRegular, 2.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "westlake-tukwilaint'lblvd",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "universityst-tukwilaint'lblvd",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "pioneersquare-tukwilaint'lblvd",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "int'ldist/chinatown-tukwilaint'lblvd",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "westlake-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "universityst-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "pioneersquare-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "int'ldist/chinatown-seatac/airport",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "westlake-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "universityst-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "pioneersquare-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "int'ldist/chinatown-anglelake",
+            ImmutableMap.of(Fare.FareType.regular, 3.0f, Fare.FareType.electronicRegular, 3.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "stadium-westlake",
+            ImmutableMap.of(Fare.FareType.regular, 2.25f, Fare.FareType.electronicRegular, 2.25f)
+        );
+
+    }
+}

--- a/src/main/java/org/opentripplanner/routing/impl/SoundTransitSounderFares.java
+++ b/src/main/java/org/opentripplanner/routing/impl/SoundTransitSounderFares.java
@@ -1,0 +1,261 @@
+package org.opentripplanner.routing.impl;
+
+import com.google.common.collect.ImmutableMap;
+import org.opentripplanner.routing.core.Fare;
+
+import java.util.Map;
+
+public class SoundTransitSounderFares {
+    public static void populateSounderFares(Map<String, Map<Fare.FareType, Float>> linkLightRailFares) {
+        linkLightRailFares.put(
+            "everett-mukilteo",
+            ImmutableMap.of(Fare.FareType.regular, 3.25f, Fare.FareType.electronicRegular, 3.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "everett-edmonds",
+            ImmutableMap.of(Fare.FareType.regular, 4.0f, Fare.FareType.electronicRegular, 4.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "everett-kingstreet",
+            ImmutableMap.of(Fare.FareType.regular, 5.0f, Fare.FareType.electronicRegular, 5.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "mukilteo-edmonds",
+            ImmutableMap.of(Fare.FareType.regular, 3.75f, Fare.FareType.electronicRegular, 3.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "mukilteo-kingstreet",
+            ImmutableMap.of(Fare.FareType.regular, 4.5f, Fare.FareType.electronicRegular, 4.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "edmonds-kingstreet",
+            ImmutableMap.of(Fare.FareType.regular, 4.0f, Fare.FareType.electronicRegular, 4.0f)
+        );
+
+        linkLightRailFares.put(
+            "lakewood-southtacomadome",
+            ImmutableMap.of(Fare.FareType.regular, 3.25f, Fare.FareType.electronicRegular, 3.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "lakewood-tacomadome",
+            ImmutableMap.of(Fare.FareType.regular, 3.5f, Fare.FareType.electronicRegular, 3.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "lakewood-puyallup",
+            ImmutableMap.of(Fare.FareType.regular, 4.0f, Fare.FareType.electronicRegular, 4.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "lakewood-sumner",
+            ImmutableMap.of(Fare.FareType.regular, 4.0f, Fare.FareType.electronicRegular, 4.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "lakewood-auburn",
+            ImmutableMap.of(Fare.FareType.regular, 4.5f, Fare.FareType.electronicRegular, 4.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "lakewood-kent",
+            ImmutableMap.of(Fare.FareType.regular, 4.75f, Fare.FareType.electronicRegular, 4.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "lakewood-tukwila",
+            ImmutableMap.of(Fare.FareType.regular, 5.0f, Fare.FareType.electronicRegular, 5.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "lakewood-kingstreet",
+            ImmutableMap.of(Fare.FareType.regular, 5.75f, Fare.FareType.electronicRegular, 5.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "southtacomadome-tacomadome",
+            ImmutableMap.of(Fare.FareType.regular, 3.25f, Fare.FareType.electronicRegular, 3.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "southtacomadome-puyallup",
+            ImmutableMap.of(Fare.FareType.regular, 3.75f, Fare.FareType.electronicRegular, 3.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "southtacomadome-sumner",
+            ImmutableMap.of(Fare.FareType.regular, 4.0f, Fare.FareType.electronicRegular, 4.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "southtacomadome-auburn",
+            ImmutableMap.of(Fare.FareType.regular, 4.25f, Fare.FareType.electronicRegular, 4.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "southtacomadome-kent",
+            ImmutableMap.of(Fare.FareType.regular, 4.5f, Fare.FareType.electronicRegular, 4.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "southtacomadome-tukwila",
+            ImmutableMap.of(Fare.FareType.regular, 5.0f, Fare.FareType.electronicRegular, 5.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "southtacomadome-kingstreet",
+            ImmutableMap.of(Fare.FareType.regular, 5.5f, Fare.FareType.electronicRegular, 5.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "tacomadome-puyallup",
+            ImmutableMap.of(Fare.FareType.regular, 3.5f, Fare.FareType.electronicRegular, 3.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "tacomadome-sumner",
+            ImmutableMap.of(Fare.FareType.regular, 3.5f, Fare.FareType.electronicRegular, 3.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "tacomadome-auburn",
+            ImmutableMap.of(Fare.FareType.regular, 4.0f, Fare.FareType.electronicRegular, 4.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "tacomadome-kent",
+            ImmutableMap.of(Fare.FareType.regular, 4.25f, Fare.FareType.electronicRegular, 4.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "tacomadome-tukwila",
+            ImmutableMap.of(Fare.FareType.regular, 4.5f, Fare.FareType.electronicRegular, 4.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "tacomadome-kingstreet",
+            ImmutableMap.of(Fare.FareType.regular, 5.25f, Fare.FareType.electronicRegular, 5.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "puyallup-sumner",
+            ImmutableMap.of(Fare.FareType.regular, 3.25f, Fare.FareType.electronicRegular, 3.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "puyallup-auburn",
+            ImmutableMap.of(Fare.FareType.regular, 3.5f, Fare.FareType.electronicRegular, 3.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "puyallup-kent",
+            ImmutableMap.of(Fare.FareType.regular, 4.0f, Fare.FareType.electronicRegular, 4.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "puyallup-tukwila",
+            ImmutableMap.of(Fare.FareType.regular, 4.25f, Fare.FareType.electronicRegular, 4.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "puyallup-kingstreet",
+            ImmutableMap.of(Fare.FareType.regular, 4.75f, Fare.FareType.electronicRegular, 4.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "sumner-auburn",
+            ImmutableMap.of(Fare.FareType.regular, 3.5f, Fare.FareType.electronicRegular, 3.5f)
+        );
+
+
+        linkLightRailFares.put(
+            "sumner-kent",
+            ImmutableMap.of(Fare.FareType.regular, 3.75f, Fare.FareType.electronicRegular, 3.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "sumner-tukwila",
+            ImmutableMap.of(Fare.FareType.regular, 4.0f, Fare.FareType.electronicRegular, 4.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "sumner-kingstreet",
+            ImmutableMap.of(Fare.FareType.regular, 4.75f, Fare.FareType.electronicRegular, 4.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "auburn-kent",
+            ImmutableMap.of(Fare.FareType.regular, 3.25f, Fare.FareType.electronicRegular, 3.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "auburn-tukwila",
+            ImmutableMap.of(Fare.FareType.regular, 3.75f, Fare.FareType.electronicRegular, 3.75f)
+        );
+
+
+        linkLightRailFares.put(
+            "auburn-kingstreet",
+            ImmutableMap.of(Fare.FareType.regular, 4.25f, Fare.FareType.electronicRegular, 4.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "kent-tukwila",
+            ImmutableMap.of(Fare.FareType.regular, 3.25f, Fare.FareType.electronicRegular, 3.25f)
+        );
+
+
+        linkLightRailFares.put(
+            "kent-kingstreet",
+            ImmutableMap.of(Fare.FareType.regular, 4.0f, Fare.FareType.electronicRegular, 4.0f)
+        );
+
+
+        linkLightRailFares.put(
+            "tukwila-kingstreet",
+            ImmutableMap.of(Fare.FareType.regular, 3.75f, Fare.FareType.electronicRegular, 3.75f)
+        );
+
+    }
+}

--- a/src/main/java/org/opentripplanner/routing/impl/SoundTransitSounderFares.java
+++ b/src/main/java/org/opentripplanner/routing/impl/SoundTransitSounderFares.java
@@ -5,6 +5,12 @@ import org.opentripplanner.routing.core.Fare;
 
 import java.util.Map;
 
+/**
+ * Class used to store all the fares for Sounder commuter rail.
+ * Data comes from a Python script that parses SoundTransit's website.
+ * A matrix or CSV parser would be a better approach to storing this data,
+ * but a refactor is unneeded given the proximity of GTFS Fares V2 which will render this redundant.
+ */
 public class SoundTransitSounderFares {
     public static void populateSounderFares(Map<String, Map<Fare.FareType, Float>> linkLightRailFares) {
         linkLightRailFares.put(

--- a/src/test/java/org/opentripplanner/routing/fares/OrcaFareServiceTest.java
+++ b/src/test/java/org/opentripplanner/routing/fares/OrcaFareServiceTest.java
@@ -19,11 +19,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.opentripplanner.routing.impl.OrcaFareServiceImpl.COMM_TRANS_AGENCY_ID;
-import static org.opentripplanner.routing.impl.OrcaFareServiceImpl.DEFAULT_TEST_RIDE_PRICE;
 import static org.opentripplanner.routing.impl.OrcaFareServiceImpl.KC_METRO_AGENCY_ID;
 import static org.opentripplanner.routing.impl.OrcaFareServiceImpl.KITSAP_TRANSIT_AGENCY_ID;
 import static org.opentripplanner.routing.impl.OrcaFareServiceImpl.PIERCE_COUNTY_TRANSIT_AGENCY_ID;
-import static org.opentripplanner.routing.impl.OrcaFareServiceImpl.SEATTLE_STREET_CAR_AGENCY_ID;
 import static org.opentripplanner.routing.impl.OrcaFareServiceImpl.SKAGIT_TRANSIT_AGENCY_ID;
 import static org.opentripplanner.routing.impl.OrcaFareServiceImpl.SOUND_TRANSIT_AGENCY_ID;
 import static org.opentripplanner.routing.impl.OrcaFareServiceImpl.WASHINGTON_STATE_FERRIES_AGENCY_ID;

--- a/src/test/java/org/opentripplanner/routing/fares/OrcaFareServiceTest.java
+++ b/src/test/java/org/opentripplanner/routing/fares/OrcaFareServiceTest.java
@@ -230,7 +230,7 @@ public class OrcaFareServiceTest {
     }
 
     /**
-     * Single trip with Link Light Rail to  ensure distance fare is calculated correctly.
+     * Single trip with Link Light Rail to ensure distance fare is calculated correctly.
      */
     @Test
     public void calculateFareForLightRailRide() {


### PR DESCRIPTION
To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [na] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

- Adds Link light rail fares for every station pair
- Adds calculation for Metro cash transfer slips
- Adds ability for transfers to be extended by paying a higher fare than the transfer within 2 hours.