### PR TITLE
Add railway=stop to OSMNode isStop() conditions

### DIFF
--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMNode.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMNode.java
@@ -48,6 +48,7 @@ public class OSMNode extends OSMWithTags {
                 || "tram_stop".equals(getTag("railway"))
                 || "station".equals(getTag("railway"))
                 || "halt".equals(getTag("railway"))
+                || "stop".equals(getTag("railway"))
                 || "bus_station".equals(getTag("amenity"));
     }
 


### PR DESCRIPTION
Updates the isStop() method of OSMNode to additionally check for the `railway=stop` condition (in additional to `railway=station` and `railway=halt`). The `railway=stop` tag is often used for tagging one or more specific boarding location(s) for trains within a larger station complex.