### PR TITLE
Add new Atlanta way property set source to allow walking on trunk roads

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/AtlantaWayPropertySetSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/AtlantaWayPropertySetSource.java
@@ -19,6 +19,9 @@ public class AtlantaWayPropertySetSource implements WayPropertySetSource {
         // Replace existing matching properties as the logic is that the first statement registered takes precedence over later statements
         props.setProperties("highway=trunk_link", StreetTraversalPermission.ALL, 2.5, 2.5);
         props.setProperties("highway=trunk", StreetTraversalPermission.ALL, 2.5, 2.5);
+
+        // Read the rest from the default set
+        new DefaultWayPropertySetSource().populateProperties(props);
     }
 }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/AtlantaWayPropertySetSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/AtlantaWayPropertySetSource.java
@@ -1,0 +1,24 @@
+package org.opentripplanner.graph_builder.module.osm;
+
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+
+/**
+ * OSM way properties for the Atlanta, Georgia, USA area.
+ * The differences compared to the default property set are:
+ * 1. In Atlanta "trunk" is used for the most important primary thoroughfares, but these roads typically
+ * still allow pedestrian traffic and often include bus service / stops.
+ *
+ * @author demory
+ * @see WayPropertySetSource
+ * @see DefaultWayPropertySetSource
+ */
+
+public class AtlantaWayPropertySetSource implements WayPropertySetSource {
+    @Override
+    public void populateProperties(WayPropertySet props) {
+        // Replace existing matching properties as the logic is that the first statement registered takes precedence over later statements
+        props.setProperties("highway=trunk_link", StreetTraversalPermission.ALL, 2.5, 2.5);
+        props.setProperties("highway=trunk", StreetTraversalPermission.ALL, 2.5, 2.5);
+    }
+}
+

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySetSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySetSource.java
@@ -23,7 +23,7 @@ public interface WayPropertySetSource {
 			return new NorwayWayPropertySetSource();
 		} else if ("uk".equals(type)) {
 			return new UKWayPropertySetSource();
-		} else if ("atl".equals(type)) {
+		} else if ("atlanta".equals(type)) {
 			return new AtlantaWayPropertySetSource();
 		} else {
 			throw new IllegalArgumentException(String.format("Unknown osmWayPropertySet: '%s'", type));

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySetSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySetSource.java
@@ -23,6 +23,8 @@ public interface WayPropertySetSource {
 			return new NorwayWayPropertySetSource();
 		} else if ("uk".equals(type)) {
 			return new UKWayPropertySetSource();
+		} else if ("atl".equals(type)) {
+			return new AtlantaWayPropertySetSource();
 		} else {
 			throw new IllegalArgumentException(String.format("Unknown osmWayPropertySet: '%s'", type));
 		}

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/AtlantaWayPropertySetSourceTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/AtlantaWayPropertySetSourceTest.java
@@ -16,8 +16,8 @@ class AtlantaWayPropertySetSourceTest {
 
     static {
         AtlantaWayPropertySetSource source = new AtlantaWayPropertySetSource();
-        wps.index();
         source.populateProperties(wps);
+        wps.index();
     }
 
     @ParameterizedTest

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/AtlantaWayPropertySetSourceTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/AtlantaWayPropertySetSourceTest.java
@@ -1,0 +1,79 @@
+package org.opentripplanner.graph_builder.module.osm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.openstreetmap.model.OSMWithTags;
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+
+import java.util.stream.Stream;
+
+class AtlantaWayPropertySetSourceTest {
+
+    static WayPropertySet wps = new WayPropertySet();
+
+    static {
+        AtlantaWayPropertySetSource source = new AtlantaWayPropertySetSource();
+        wps.index();
+        source.populateProperties(wps);
+    }
+
+    @ParameterizedTest
+    @MethodSource("createTrunkRoadPermissionsTestCases")
+    void testTrunkRoadPermissions(OSMWithTags way, String description) {
+        assertEquals(StreetTraversalPermission.ALL, wps.getDataForWay(way).getPermission(), description);
+    }
+
+    private static Stream<Arguments> createTrunkRoadPermissionsTestCases() {
+        // Most OSM trunk roads in Atlanta are (large) city roads that are permitted for all modes.
+        // (The default WayPropertySetSource implementation is car-only.)
+        // TODO: Handle exceptions such as:
+        //  - Northside Drive between Marietta Street and Tech Parkway (northbound)
+        //    (https://www.openstreetmap.org/way/96395009, no sidewalk, but possible to bike)
+        //  - Portions of Freedom Parkway that are freeway/motorway-like (https://www.openstreetmap.org/way/88171817)
+
+        // Peachtree Rd in Atlanta has sidewalks, and bikes are allowed.
+        // https://www.openstreetmap.org/way/144429544
+        OSMWithTags peachtreeRd = new OSMWithTags();
+        peachtreeRd.addTag("highway", "trunk");
+        peachtreeRd.addTag("lanes", "6");
+        peachtreeRd.addTag("name", "Peachtree Road");
+        peachtreeRd.addTag("ref", "US 19;GA 9");
+        peachtreeRd.addTag("surface", "asphalt");
+        peachtreeRd.addTag("tiger:county", "Fulton, GA");
+
+        // "Outer" ramps from DeKalb Ave onto Moreland Ave in Atlanta have sidewalks, and bikes are allowed.
+        // https://www.openstreetmap.org/way/9164434
+        OSMWithTags morelandRamp = new OSMWithTags();
+        morelandRamp.addTag("highway", "trunk_link");
+        morelandRamp.addTag("lanes", "1");
+        morelandRamp.addTag("oneway", "yes");
+        morelandRamp.addTag("tiger:cfcc", "A63");
+        morelandRamp.addTag("tiger:county", "DeKalb, GA");
+        morelandRamp.addTag("tiger:reviewed", "no");
+
+        // For sanity check, secondary roads (e.g. 10th Street) should remain allowed for all modes.
+        // https://www.openstreetmap.org/way/505912700
+        OSMWithTags tenthSt = new OSMWithTags();
+        tenthSt.addTag("highway", "secondary");
+        tenthSt.addTag("lanes", "4");
+        tenthSt.addTag("maxspeed", "30 mph");
+        tenthSt.addTag("name", "10th Street Northeast");
+        tenthSt.addTag("oneway", "no");
+        tenthSt.addTag("source:maxspeed", "sign");
+        tenthSt.addTag("surface", "asphalt");
+        tenthSt.addTag("tiger:cfcc", "A41");
+        tenthSt.addTag("tiger:county", "Fulton, GA");
+        tenthSt.addTag("tiger:reviewed", "no");
+        // Some other params omitted.
+
+
+        return Stream.of(
+            Arguments.of(peachtreeRd, "Peachtree Road (trunk)"),
+            Arguments.of(morelandRamp, "Moreland Avenue Ramp (trunk_link)"),
+            Arguments.of(tenthSt, "10th Street NE (secondary)")
+        );
+    }
+}


### PR DESCRIPTION
Adds Atlanta-specific OSM way property set source, specifically to allow walking on "trunk" roads which in the Atlanta area are typically major/primary roads that still allow walking and often have bus service. 

To enable, build graph with `"osmWayPropertySet": "atl"` included in build-config.json.

Sample search: walk+transit from 58 Brighton Rd NE in Atlanta to North Avenue MARTA station. With the default way property set, walking is not allowed on Peachtree Rd (a 'trunk' road) and the walk access leg is unnecessarily long/indirect:

![image](https://user-images.githubusercontent.com/653100/169625144-f7026e6a-7941-4eb8-a42f-9c895075a6b7.png)

With the Atlanta property set enabled, walking will be allowed on Peachtree Rd and the walk access leg should be more direct:
<img width="925" alt="image" src="https://user-images.githubusercontent.com/653100/169625025-6569fb69-5b97-4c5a-99e8-bed1f62f234d.png">
