### PR TITLE
fix(orca-fares): update and fix WSF fares

### DIFF
--- a/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
@@ -269,7 +269,7 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
             case electronicYouth:
                 return getYouthFare(fareType, rideType, defaultFare, ride.routeData);
             case electronicSpecial:
-                return getLiftFare(rideType, defaultFare);
+                return getLiftFare(rideType, defaultFare, ride.routeData);
             case electronicSenior:
             case senior:
                 return getSeniorFare(fareType, rideType, defaultFare, ride.routeData);
@@ -335,7 +335,7 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
     /**
      * Apply Orca lift discount fares based on the ride type.
      */
-    private float getLiftFare(RideType rideType, float defaultFare) {
+    private float getLiftFare(RideType rideType, float defaultFare, Route route) {
         switch (rideType) {
             case COMM_TRANS_LOCAL_SWIFT: return 1.25f;
             case COMM_TRANS_COMMUTER_EXPRESS: return 2.00f;
@@ -351,6 +351,8 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
             case SEATTLE_STREET_CAR:
                 return 1.50f;
             case PIERCE_COUNTY_TRANSIT:
+            case WASHINGTON_STATE_FERRIES:
+                return getWashingtonStateFerriesFare(route.getLongName(), Fare.FareType.electronicSpecial, defaultFare);
             default:
                 return defaultFare;
         }

--- a/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
@@ -137,59 +137,59 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
         // Spaces have been removed from the route name because of inconsistencies in the WSF GTFS route dataset.
         washingtonStateFerriesFares.put(
             "Seattle-BainbridgeIsland",
-            ImmutableMap.of(Fare.FareType.regular, 9.05f, Fare.FareType.youth, 4.50f, Fare.FareType.senior, 4.50f)
+            ImmutableMap.of(Fare.FareType.regular, 9.25f, Fare.FareType.youth, 4.60f, Fare.FareType.senior, 4.60f)
         );
         washingtonStateFerriesFares.put(
             "Seattle-Bremerton",
-            ImmutableMap.of(Fare.FareType.regular, 9.05f, Fare.FareType.youth, 4.50f, Fare.FareType.senior, 4.50f)
+            ImmutableMap.of(Fare.FareType.regular, 9.25f, Fare.FareType.youth, 4.60f, Fare.FareType.senior, 4.60f)
         );
         washingtonStateFerriesFares.put(
             "Mukilteo-Clinton",
-            ImmutableMap.of(Fare.FareType.regular, 5.55f, Fare.FareType.youth, 2.75f, Fare.FareType.senior, 2.75f)
+            ImmutableMap.of(Fare.FareType.regular, 5.65f, Fare.FareType.youth, 2.80f, Fare.FareType.senior, 2.80f)
         );
         washingtonStateFerriesFares.put(
             "Fauntleroy-VashonIsland",
-            ImmutableMap.of(Fare.FareType.regular, 5.95f, Fare.FareType.youth, 2.95f, Fare.FareType.senior, 2.95f)
+            ImmutableMap.of(Fare.FareType.regular, 6.10f, Fare.FareType.youth, 3.05f, Fare.FareType.senior, 3.05f)
         );
         washingtonStateFerriesFares.put(
             "Fauntleroy-Southworth",
-            ImmutableMap.of(Fare.FareType.regular, 7.10f, Fare.FareType.youth, 3.55f, Fare.FareType.senior, 3.55f)
+            ImmutableMap.of(Fare.FareType.regular, 7.20f, Fare.FareType.youth, 3.60f, Fare.FareType.senior, 3.60f)
         );
         washingtonStateFerriesFares.put(
             "Edmonds-Kingston",
-            ImmutableMap.of(Fare.FareType.regular, 9.05f, Fare.FareType.youth, 4.50f, Fare.FareType.senior, 4.50f)
+            ImmutableMap.of(Fare.FareType.regular, 9.25f, Fare.FareType.youth, 4.60f, Fare.FareType.senior, 4.60f)
         );
         washingtonStateFerriesFares.put(
             "PointDefiance-Tahlequah",
-            ImmutableMap.of(Fare.FareType.regular, 5.95f, Fare.FareType.youth, 2.95f, Fare.FareType.senior, 2.95f)
+            ImmutableMap.of(Fare.FareType.regular, 6.10f, Fare.FareType.youth, 3.05f, Fare.FareType.senior, 3.05f)
         );
         washingtonStateFerriesFares.put(
             "Anacortes-FridayHarbor",
-            ImmutableMap.of(Fare.FareType.regular, 14.50f, Fare.FareType.youth, 7.25f, Fare.FareType.senior, 7.25f)
+            ImmutableMap.of(Fare.FareType.regular, 14.85f, Fare.FareType.youth, 7.40f, Fare.FareType.senior, 7.40f)
         );
         washingtonStateFerriesFares.put(
             "Anacortes-LopezIsland",
-            ImmutableMap.of(Fare.FareType.regular, 14.50f, Fare.FareType.youth, 7.25f, Fare.FareType.senior, 7.25f)
+            ImmutableMap.of(Fare.FareType.regular, 14.85f, Fare.FareType.youth, 7.40f, Fare.FareType.senior, 7.40f)
         );
         washingtonStateFerriesFares.put(
             "Anacortes-OrcasIsland",
-            ImmutableMap.of(Fare.FareType.regular, 14.50f, Fare.FareType.youth, 7.25f, Fare.FareType.senior, 7.25f)
+            ImmutableMap.of(Fare.FareType.regular, 14.85f, Fare.FareType.youth, 7.40f, Fare.FareType.senior, 7.40f)
         );
         washingtonStateFerriesFares.put(
             "Anacortes-ShawIsland",
-            ImmutableMap.of(Fare.FareType.regular, 14.50f, Fare.FareType.youth, 7.25f, Fare.FareType.senior, 7.25f)
+            ImmutableMap.of(Fare.FareType.regular, 14.85f, Fare.FareType.youth, 7.40f, Fare.FareType.senior, 7.40f)
         );
         washingtonStateFerriesFares.put(
             "Coupeville-PortTownsend",
-            ImmutableMap.of(Fare.FareType.regular, 3.80f, Fare.FareType.youth, 1.80f, Fare.FareType.senior, 1.80f)
+            ImmutableMap.of(Fare.FareType.regular, 3.85f, Fare.FareType.youth, 1.90f, Fare.FareType.senior, 1.90f)
         );
         washingtonStateFerriesFares.put(
             "PortTownsend-Coupeville",
-            ImmutableMap.of(Fare.FareType.regular, 3.80f, Fare.FareType.youth, 1.80f, Fare.FareType.senior, 1.80f)
+            ImmutableMap.of(Fare.FareType.regular, 3.85f, Fare.FareType.youth, 1.90f, Fare.FareType.senior, 1.90f)
         );
         washingtonStateFerriesFares.put(
             "Southworth-VashonIsland",
-            ImmutableMap.of(Fare.FareType.regular, 5.95f, Fare.FareType.youth, 2.95f, Fare.FareType.senior, 2.95f)
+            ImmutableMap.of(Fare.FareType.regular, 6.10f, Fare.FareType.youth, 3.05f, Fare.FareType.senior, 3.05f)
         );
 
         SoundTransitLinkFares.populateLinkFares(soundTransitLinkFares);
@@ -436,7 +436,7 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
         }
         Map<Fare.FareType, Float> fares = washingtonStateFerriesFares.get(routeLongName.replaceAll(" ", ""));
         // WSF is free in one direction on each route
-        return (fares != null && fares.get(fareType) != null) ? fares.get(fareType) : defaultFare;
+        return (fares != null && fares.get(fareType) != null) ? fares.get(fareType) : 0;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
@@ -33,7 +33,7 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
     public static final String PIERCE_COUNTY_TRANSIT_AGENCY_ID = "3";
     public static final String SKAGIT_TRANSIT_AGENCY_ID = "e0e4541a-2714-487b-b30c-f5c6cb4a310f";
     public static final String SEATTLE_STREET_CAR_AGENCY_ID = "23";
-    public static final String WASHINGTON_STATE_FERRIES_AGENCY_ID = "wsf";
+    public static final String WASHINGTON_STATE_FERRIES_AGENCY_ID = "WSF";
     public static final String KITSAP_TRANSIT_AGENCY_ID = "kt";
     public static final int ROUTE_TYPE_FERRY = 4;
 
@@ -434,8 +434,9 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
         if (routeLongName == null || routeLongName.isEmpty()) {
             return defaultFare;
         }
-        Float fare = washingtonStateFerriesFares.get(routeLongName.replaceAll(" ", "")).get(fareType);
-        return (fare != null) ? fare : defaultFare;
+        Map<Fare.FareType, Float> fares = washingtonStateFerriesFares.get(routeLongName.replaceAll(" ", ""));
+        // WSF is free in one direction on each route
+        return (fares != null && fares.get(fareType) != null) ? fares.get(fareType) : defaultFare;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
@@ -451,6 +451,8 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
             wsfFareType = fareType;
         }
         // WSF is free in one direction on each route
+        // If a fare is not found in the map, we can assume it's free.
+        // Route long name is reversed for the reverse direction on a single WSF route
         return (fares != null && fares.get(wsfFareType) != null) ? fares.get(wsfFareType) : 0;
     }
 

--- a/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
@@ -435,8 +435,21 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
             return defaultFare;
         }
         Map<Fare.FareType, Float> fares = washingtonStateFerriesFares.get(routeLongName.replaceAll(" ", ""));
+        // WSF doesn't support transfers so we only care about cash fares.
+        Fare.FareType wsfFareType;
+        if (fareType == Fare.FareType.electronicRegular) {
+            wsfFareType = Fare.FareType.regular;
+        } else if(fareType == Fare.FareType.electronicSenior) {
+            wsfFareType = Fare.FareType.senior;
+        } else if(fareType == Fare.FareType.electronicYouth) {
+            wsfFareType = Fare.FareType.youth;
+        } else if(fareType == Fare.FareType.electronicSpecial) {
+            wsfFareType = Fare.FareType.regular;
+        } else {
+            wsfFareType = fareType;
+        }
         // WSF is free in one direction on each route
-        return (fares != null && fares.get(fareType) != null) ? fares.get(fareType) : 0;
+        return (fares != null && fares.get(wsfFareType) != null) ? fares.get(wsfFareType) : 0;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
@@ -350,9 +350,9 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
             case EVERETT_TRANSIT:
             case SEATTLE_STREET_CAR:
                 return 1.50f;
-            case PIERCE_COUNTY_TRANSIT:
             case WASHINGTON_STATE_FERRIES:
                 return getWashingtonStateFerriesFare(route.getLongName(), Fare.FareType.electronicSpecial, defaultFare);
+            case PIERCE_COUNTY_TRANSIT:
             default:
                 return defaultFare;
         }

--- a/src/test/java/org/opentripplanner/routing/fares/OrcaFareServiceTest.java
+++ b/src/test/java/org/opentripplanner/routing/fares/OrcaFareServiceTest.java
@@ -111,7 +111,7 @@ public class OrcaFareServiceTest {
     /**
      * Total trip time is 2h 30m. The first four transfers are within the permitted two hour window. A single (highest)
      * Orca fare will be charged for these transfers. The fifth transfer is outside of the original two hour window so
-     * a single Orca fare for this leg is applied and the two hour window will start again. The final transfer is within
+     * a sigle Orca fare for this leg is applied and the two hour window will start again. The final transfer is within
      * the new two hour window and will be free.
      */
     @Test
@@ -237,13 +237,13 @@ public class OrcaFareServiceTest {
         List<Ride> rides = Collections.singletonList(
             getRide(WASHINGTON_STATE_FERRIES_AGENCY_ID, 0, "Point Defiance - Tahlequah")
         );
-        calculateFare(rides, Fare.FareType.regular, 595f);
-        calculateFare(rides, Fare.FareType.senior, 295f);
-        calculateFare(rides, Fare.FareType.youth, 295f);
-        calculateFare(rides, Fare.FareType.electronicSpecial, DEFAULT_RIDE_PRICE_IN_CENTS);
-        calculateFare(rides, Fare.FareType.electronicRegular, DEFAULT_RIDE_PRICE_IN_CENTS);
-        calculateFare(rides, Fare.FareType.electronicSenior, DEFAULT_RIDE_PRICE_IN_CENTS);
-        calculateFare(rides, Fare.FareType.electronicYouth, DEFAULT_RIDE_PRICE_IN_CENTS);
+        calculateFare(rides, Fare.FareType.regular, 610f);
+        calculateFare(rides, Fare.FareType.senior, 305f);
+        calculateFare(rides, Fare.FareType.youth, 305f);
+        calculateFare(rides, Fare.FareType.electronicSpecial, 610f);
+        calculateFare(rides, Fare.FareType.electronicRegular, 610f);
+        calculateFare(rides, Fare.FareType.electronicSenior, 305f);
+        calculateFare(rides, Fare.FareType.electronicYouth, 305f);
     }
 
     /**

--- a/src/test/java/org/opentripplanner/routing/fares/OrcaFareServiceTest.java
+++ b/src/test/java/org/opentripplanner/routing/fares/OrcaFareServiceTest.java
@@ -142,23 +142,19 @@ public class OrcaFareServiceTest {
     public void calculateFareThatIncludesNoFreeTransfers() {
         List<Ride> rides = Arrays.asList(
             getRide(KITSAP_TRANSIT_AGENCY_ID, 0),
-            getRide(WASHINGTON_STATE_FERRIES_AGENCY_ID, 30),
+            getRide(WASHINGTON_STATE_FERRIES_AGENCY_ID, 30, "VashonIsland-Fauntelroy"),
             getRide(KITSAP_TRANSIT_AGENCY_ID, 60),
             getRide(SKAGIT_TRANSIT_AGENCY_ID, 90),
             getRide(KITSAP_TRANSIT_AGENCY_ID, 120),
             getRide(WASHINGTON_STATE_FERRIES_AGENCY_ID, 150, "Fauntleroy-VashonIsland")
         );
-        calculateFare(rides, Fare.FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS * 5 + 595f);
-        calculateFare(rides, Fare.FareType.senior, DEFAULT_RIDE_PRICE_IN_CENTS * 3 + 50f +
-            DEFAULT_RIDE_PRICE_IN_CENTS + 295f);
-        calculateFare(rides, Fare.FareType.youth, 200f + DEFAULT_RIDE_PRICE_IN_CENTS + 200f + 50f + 200f + 295f);
-        calculateFare(rides, Fare.FareType.electronicSpecial, 100f + DEFAULT_RIDE_PRICE_IN_CENTS + 0f +
-            DEFAULT_RIDE_PRICE_IN_CENTS + 100f + DEFAULT_RIDE_PRICE_IN_CENTS);
-        calculateFare(rides, Fare.FareType.electronicRegular, DEFAULT_RIDE_PRICE_IN_CENTS * 2 + 0f +
-            DEFAULT_RIDE_PRICE_IN_CENTS * 3);
-        calculateFare(rides, Fare.FareType.electronicSenior, 100f + DEFAULT_RIDE_PRICE_IN_CENTS + 0f +
-            50f + 100f + DEFAULT_RIDE_PRICE_IN_CENTS);
-        calculateFare(rides, Fare.FareType.electronicYouth, 100f + DEFAULT_RIDE_PRICE_IN_CENTS + 0f + 50f + 100f + DEFAULT_RIDE_PRICE_IN_CENTS);
+        calculateFare(rides, Fare.FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS * 4 + 610f);
+        calculateFare(rides, Fare.FareType.senior, DEFAULT_RIDE_PRICE_IN_CENTS * 3 + 50f + 305f);
+        calculateFare(rides, Fare.FareType.youth, 200f + 200f + 50f + 200f + 305f);
+        calculateFare(rides, Fare.FareType.electronicSpecial, 100f + DEFAULT_RIDE_PRICE_IN_CENTS + 100f + 610f);
+        calculateFare(rides, Fare.FareType.electronicRegular, DEFAULT_RIDE_PRICE_IN_CENTS * 3 + 610f);
+        calculateFare(rides, Fare.FareType.electronicSenior, 100f + 50f + 100f + 305f);
+        calculateFare(rides, Fare.FareType.electronicYouth, 100f + 50f + 100f + 305f);
     }
 
     /**

--- a/src/test/java/org/opentripplanner/routing/fares/OrcaFareServiceTest.java
+++ b/src/test/java/org/opentripplanner/routing/fares/OrcaFareServiceTest.java
@@ -111,7 +111,7 @@ public class OrcaFareServiceTest {
     /**
      * Total trip time is 2h 30m. The first four transfers are within the permitted two hour window. A single (highest)
      * Orca fare will be charged for these transfers. The fifth transfer is outside of the original two hour window so
-     * a sigle Orca fare for this leg is applied and the two hour window will start again. The final transfer is within
+     * a single Orca fare for this leg is applied and the two hour window will start again. The final transfer is within
      * the new two hour window and will be free.
      */
     @Test


### PR DESCRIPTION
This fixes the calculation for Washington State Ferries fares. The ferries are free in one direction, so I've changed the calculation to make the price zero if we do not have a fare value stored for a route. (The route name is different in each direction)

- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 