### PR TITLE
fix(orca-fares): make youth fares free

### DIFF
--- a/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/OrcaFareServiceImpl.java
@@ -137,59 +137,59 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
         // Spaces have been removed from the route name because of inconsistencies in the WSF GTFS route dataset.
         washingtonStateFerriesFares.put(
             "Seattle-BainbridgeIsland",
-            ImmutableMap.of(Fare.FareType.regular, 9.25f, Fare.FareType.youth, 4.60f, Fare.FareType.senior, 4.60f)
+            ImmutableMap.of(Fare.FareType.regular, 9.25f, Fare.FareType.senior, 4.60f)
         );
         washingtonStateFerriesFares.put(
             "Seattle-Bremerton",
-            ImmutableMap.of(Fare.FareType.regular, 9.25f, Fare.FareType.youth, 4.60f, Fare.FareType.senior, 4.60f)
+            ImmutableMap.of(Fare.FareType.regular, 9.25f, Fare.FareType.senior, 4.60f)
         );
         washingtonStateFerriesFares.put(
             "Mukilteo-Clinton",
-            ImmutableMap.of(Fare.FareType.regular, 5.65f, Fare.FareType.youth, 2.80f, Fare.FareType.senior, 2.80f)
+            ImmutableMap.of(Fare.FareType.regular, 5.65f, Fare.FareType.senior, 2.80f)
         );
         washingtonStateFerriesFares.put(
             "Fauntleroy-VashonIsland",
-            ImmutableMap.of(Fare.FareType.regular, 6.10f, Fare.FareType.youth, 3.05f, Fare.FareType.senior, 3.05f)
+            ImmutableMap.of(Fare.FareType.regular, 6.10f, Fare.FareType.senior, 3.05f)
         );
         washingtonStateFerriesFares.put(
             "Fauntleroy-Southworth",
-            ImmutableMap.of(Fare.FareType.regular, 7.20f, Fare.FareType.youth, 3.60f, Fare.FareType.senior, 3.60f)
+            ImmutableMap.of(Fare.FareType.regular, 7.20f, Fare.FareType.senior, 3.60f)
         );
         washingtonStateFerriesFares.put(
             "Edmonds-Kingston",
-            ImmutableMap.of(Fare.FareType.regular, 9.25f, Fare.FareType.youth, 4.60f, Fare.FareType.senior, 4.60f)
+            ImmutableMap.of(Fare.FareType.regular, 9.25f, Fare.FareType.senior, 4.60f)
         );
         washingtonStateFerriesFares.put(
             "PointDefiance-Tahlequah",
-            ImmutableMap.of(Fare.FareType.regular, 6.10f, Fare.FareType.youth, 3.05f, Fare.FareType.senior, 3.05f)
+            ImmutableMap.of(Fare.FareType.regular, 6.10f, Fare.FareType.senior, 3.05f)
         );
         washingtonStateFerriesFares.put(
             "Anacortes-FridayHarbor",
-            ImmutableMap.of(Fare.FareType.regular, 14.85f, Fare.FareType.youth, 7.40f, Fare.FareType.senior, 7.40f)
+            ImmutableMap.of(Fare.FareType.regular, 14.85f, Fare.FareType.senior, 7.40f)
         );
         washingtonStateFerriesFares.put(
             "Anacortes-LopezIsland",
-            ImmutableMap.of(Fare.FareType.regular, 14.85f, Fare.FareType.youth, 7.40f, Fare.FareType.senior, 7.40f)
+            ImmutableMap.of(Fare.FareType.regular, 14.85f, Fare.FareType.senior, 7.40f)
         );
         washingtonStateFerriesFares.put(
             "Anacortes-OrcasIsland",
-            ImmutableMap.of(Fare.FareType.regular, 14.85f, Fare.FareType.youth, 7.40f, Fare.FareType.senior, 7.40f)
+            ImmutableMap.of(Fare.FareType.regular, 14.85f, Fare.FareType.senior, 7.40f)
         );
         washingtonStateFerriesFares.put(
             "Anacortes-ShawIsland",
-            ImmutableMap.of(Fare.FareType.regular, 14.85f, Fare.FareType.youth, 7.40f, Fare.FareType.senior, 7.40f)
+            ImmutableMap.of(Fare.FareType.regular, 14.85f, Fare.FareType.senior, 7.40f)
         );
         washingtonStateFerriesFares.put(
             "Coupeville-PortTownsend",
-            ImmutableMap.of(Fare.FareType.regular, 3.85f, Fare.FareType.youth, 1.90f, Fare.FareType.senior, 1.90f)
+            ImmutableMap.of(Fare.FareType.regular, 3.85f, Fare.FareType.senior, 1.90f)
         );
         washingtonStateFerriesFares.put(
             "PortTownsend-Coupeville",
-            ImmutableMap.of(Fare.FareType.regular, 3.85f, Fare.FareType.youth, 1.90f, Fare.FareType.senior, 1.90f)
+            ImmutableMap.of(Fare.FareType.regular, 3.85f, Fare.FareType.senior, 1.90f)
         );
         washingtonStateFerriesFares.put(
             "Southworth-VashonIsland",
-            ImmutableMap.of(Fare.FareType.regular, 6.10f, Fare.FareType.youth, 3.05f, Fare.FareType.senior, 3.05f)
+            ImmutableMap.of(Fare.FareType.regular, 6.10f, Fare.FareType.senior, 3.05f)
         );
 
         SoundTransitLinkFares.populateLinkFares(soundTransitLinkFares);
@@ -267,7 +267,7 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
         switch (fareType) {
             case youth:
             case electronicYouth:
-                return getYouthFare(fareType, rideType, defaultFare, ride.routeData);
+                return getYouthFare();
             case electronicSpecial:
                 return getLiftFare(rideType, defaultFare, ride.routeData);
             case electronicSenior:
@@ -396,36 +396,10 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
 
     /**
      * Apply youth discount fares based on the ride type.
+     * Youth ride free in Puget Sound.
      */
-    private float getYouthFare(Fare.FareType fareType, RideType rideType, float defaultFare, Route route) {
-        switch (rideType) {
-            case COMM_TRANS_LOCAL_SWIFT: return 1.75f;
-            case COMM_TRANS_COMMUTER_EXPRESS: return 3.00f;
-            case KITSAP_TRANSIT:
-            case KITSAP_TRANSIT_FAST_FERRY_EASTBOUND:
-                // Discount specific to Kitsap transit.
-                return fareType.equals(Fare.FareType.electronicYouth) ? 1.00f : 2.00f;
-            case PIERCE_COUNTY_TRANSIT: return 1.00f;
-            case KC_WATER_TAXI_VASHON_ISLAND: return 4.50f;
-            case KC_WATER_TAXI_WEST_SEATTLE: return 3.75f;
-            case KC_METRO:
-            case SOUND_TRANSIT:
-            case SOUND_TRANSIT_BUS:
-            case SOUND_TRANSIT_LINK:
-            case SOUND_TRANSIT_SOUNDER:
-            case EVERETT_TRANSIT:
-            case SEATTLE_STREET_CAR: return 1.50f;
-            case KITSAP_TRANSIT_FAST_FERRY_WESTBOUND:
-                // Discount specific to Kitsap transit.
-                return fareType.equals(Fare.FareType.electronicYouth) ? 5.00f : 10.00f;
-            case SKAGIT_TRANSIT:
-                // Discount specific to Skagit transit.
-                return 0.50f;
-            case WASHINGTON_STATE_FERRIES:
-                // Discount specific to WSF.
-                return getWashingtonStateFerriesFare(route.getLongName(), fareType, defaultFare);
-            default: return defaultFare;
-        }
+    private float getYouthFare() {
+        return 0f;
     }
 
     /**
@@ -506,8 +480,8 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
                     addFareComponent(ride, fareType, currency, legFare - orcaFareDiscount, orcaFareDiscount != 0);
                     orcaFareDiscount = legFare;
                 } else {
-                    // Ride is free
-                    addFareComponent(ride, fareType, currency, 0, true);
+                    // Ride is free, counts as a transfer if legFare is NOT free
+                    addFareComponent(ride, fareType, currency, 0, legFare != 0);
                 }
            } else if (usesOrca(fareType) && !inFreeTransferWindow) {
                 // If using Orca and outside of the free transfer window, add the cumulative Orca fare (the maximum leg 
@@ -541,10 +515,10 @@ public class OrcaFareServiceImpl extends DefaultFareServiceImpl {
             }
         }
         cost += orcaFareDiscount;
-        if (cost < Float.POSITIVE_INFINITY && cost > 0) {
+        if (cost < Float.POSITIVE_INFINITY) {
             fare.addFare(fareType, getMoney(currency, cost));
         }
-        return cost > 0 && cost < Float.POSITIVE_INFINITY;
+        return cost < Float.POSITIVE_INFINITY;
     }
 
     /**

--- a/src/test/java/org/opentripplanner/routing/fares/OrcaFareServiceTest.java
+++ b/src/test/java/org/opentripplanner/routing/fares/OrcaFareServiceTest.java
@@ -64,11 +64,11 @@ public class OrcaFareServiceTest {
         );
         calculateFare(rides, Fare.FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS);
         calculateFare(rides, Fare.FareType.senior, 200f);
-        calculateFare(rides, Fare.FareType.youth, 300f);
+        calculateFare(rides, Fare.FareType.youth, 0f);
         calculateFare(rides, Fare.FareType.electronicSpecial, 200f);
         calculateFare(rides, Fare.FareType.electronicRegular, DEFAULT_RIDE_PRICE_IN_CENTS);
         calculateFare(rides, Fare.FareType.electronicSenior, 200f);
-        calculateFare(rides, Fare.FareType.electronicYouth, 300f);
+        calculateFare(rides, Fare.FareType.electronicYouth, 0f);
     }
 
     /**
@@ -84,11 +84,11 @@ public class OrcaFareServiceTest {
         );
         calculateFare(rides, Fare.FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS * 3);
         calculateFare(rides, Fare.FareType.senior, DEFAULT_RIDE_PRICE_IN_CENTS + DEFAULT_RIDE_PRICE_IN_CENTS + 125);
-        calculateFare(rides, Fare.FareType.youth, 200f + DEFAULT_RIDE_PRICE_IN_CENTS + 175f);
+        calculateFare(rides, Fare.FareType.youth, 0f);
         calculateFare(rides, Fare.FareType.electronicSpecial, 0f + DEFAULT_RIDE_PRICE_IN_CENTS + 125f);
         calculateFare(rides, Fare.FareType.electronicRegular, 0f + DEFAULT_RIDE_PRICE_IN_CENTS + DEFAULT_RIDE_PRICE_IN_CENTS);
         calculateFare(rides, Fare.FareType.electronicSenior, 0f + DEFAULT_RIDE_PRICE_IN_CENTS + 125f);
-        calculateFare(rides, Fare.FareType.electronicYouth, 0f + DEFAULT_RIDE_PRICE_IN_CENTS + 175f);
+        calculateFare(rides, Fare.FareType.electronicYouth, 0f);
     }
 
     /**
@@ -126,12 +126,12 @@ public class OrcaFareServiceTest {
         );
         calculateFare(rides, Fare.FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS * 6);
         calculateFare(rides, Fare.FareType.senior, DEFAULT_RIDE_PRICE_IN_CENTS * 6);
-        calculateFare(rides, Fare.FareType.youth, 200f + 200f + 200f + 200f + 200f + 200f);
+        calculateFare(rides, Fare.FareType.youth, 0f);
         calculateFare(rides, Fare.FareType.electronicSpecial, 100f + 0f + 0f + 0f + 100f + 0f);
         calculateFare(rides, Fare.FareType.electronicRegular, DEFAULT_RIDE_PRICE_IN_CENTS + 0f + 0f + 0f +
             DEFAULT_RIDE_PRICE_IN_CENTS + 0f);
         calculateFare(rides, Fare.FareType.electronicSenior, 100f + 0f + 0f + 0f + 100f + 0f);
-        calculateFare(rides, Fare.FareType.electronicYouth, 100f + 0f + 0f + 0f + 100f + 0f);
+        calculateFare(rides, Fare.FareType.electronicYouth, 0f);
     }
     /**
      * Total trip time is 2h 30m. Calculate fare with two free transfer windows which include agencies which do not permit
@@ -150,11 +150,11 @@ public class OrcaFareServiceTest {
         );
         calculateFare(rides, Fare.FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS * 4 + 610f);
         calculateFare(rides, Fare.FareType.senior, DEFAULT_RIDE_PRICE_IN_CENTS * 3 + 50f + 305f);
-        calculateFare(rides, Fare.FareType.youth, 200f + 200f + 50f + 200f + 305f);
+        calculateFare(rides, Fare.FareType.youth, 0f);
         calculateFare(rides, Fare.FareType.electronicSpecial, 100f + DEFAULT_RIDE_PRICE_IN_CENTS + 100f + 610f);
         calculateFare(rides, Fare.FareType.electronicRegular, DEFAULT_RIDE_PRICE_IN_CENTS * 3 + 610f);
         calculateFare(rides, Fare.FareType.electronicSenior, 100f + 50f + 100f + 305f);
-        calculateFare(rides, Fare.FareType.electronicYouth, 100f + 50f + 100f + 305f);
+        calculateFare(rides, Fare.FareType.electronicYouth, 0f);
     }
 
     /**
@@ -176,12 +176,12 @@ public class OrcaFareServiceTest {
         );
         calculateFare(rides, Fare.FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS * 10);
         calculateFare(rides, Fare.FareType.senior, DEFAULT_RIDE_PRICE_IN_CENTS * 10);
-        calculateFare(rides, Fare.FareType.youth, 200f + 200f + 200f + 200f + 200f + 200f + 200f + 200f + 200f + 200f);
+        calculateFare(rides, Fare.FareType.youth, 0f);
         calculateFare(rides, Fare.FareType.electronicSpecial, 100f + 0f + 0f + 0f + 100f + 0f + 0f + 0f + 100f + 0f);
         calculateFare(rides, Fare.FareType.electronicRegular, DEFAULT_RIDE_PRICE_IN_CENTS + 0f + 0f + 0f +
             DEFAULT_RIDE_PRICE_IN_CENTS + 0f + 0f + 0f + DEFAULT_RIDE_PRICE_IN_CENTS);
         calculateFare(rides, Fare.FareType.electronicSenior, 100f + 0f + 0f + 0f + 100f + 0f + 0f + 0f + 100f + 0f);
-        calculateFare(rides, Fare.FareType.electronicYouth, 100f + 0f + 0f + 0f + 100f + 0f + 0f + 0f + 100f + 0f);
+        calculateFare(rides, Fare.FareType.electronicYouth, 0f);
     }
 
     /**
@@ -200,12 +200,12 @@ public class OrcaFareServiceTest {
         );
         calculateFare(rides, Fare.FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS * 6);
         calculateFare(rides, Fare.FareType.senior, DEFAULT_RIDE_PRICE_IN_CENTS * 6);
-        calculateFare(rides, Fare.FareType.youth, 349f + 200f + 200f + 200f + 200f + 200f);
+        calculateFare(rides, Fare.FareType.youth, 0f);
         calculateFare(rides, Fare.FareType.electronicSpecial, DEFAULT_RIDE_PRICE_IN_CENTS + 100f + 0f + 0f + 0f + 0f);
         calculateFare(rides, Fare.FareType.electronicRegular, DEFAULT_RIDE_PRICE_IN_CENTS +
             DEFAULT_RIDE_PRICE_IN_CENTS + 0f + 0f + 0f);
         calculateFare(rides, Fare.FareType.electronicSenior, DEFAULT_RIDE_PRICE_IN_CENTS + 100f + 0f + 0f + 0f + 0f);
-        calculateFare(rides, Fare.FareType.electronicYouth, DEFAULT_RIDE_PRICE_IN_CENTS + 100f + 0f + 0f + 0f + 0f);
+        calculateFare(rides, Fare.FareType.electronicYouth, 0f);
     }
 
     /**
@@ -218,11 +218,11 @@ public class OrcaFareServiceTest {
         );
         calculateFare(rides, Fare.FareType.regular, 200f);
         calculateFare(rides, Fare.FareType.senior, 200f);
-        calculateFare(rides, Fare.FareType.youth, 200f);
+        calculateFare(rides, Fare.FareType.youth, 0f);
         calculateFare(rides, Fare.FareType.electronicSpecial, DEFAULT_RIDE_PRICE_IN_CENTS);
         calculateFare(rides, Fare.FareType.electronicRegular, 200f);
         calculateFare(rides, Fare.FareType.electronicSenior, 100f);
-        calculateFare(rides, Fare.FareType.electronicYouth, 100f);
+        calculateFare(rides, Fare.FareType.electronicYouth, 0f);
     }
 
     /**
@@ -235,11 +235,11 @@ public class OrcaFareServiceTest {
         );
         calculateFare(rides, Fare.FareType.regular, 610f);
         calculateFare(rides, Fare.FareType.senior, 305f);
-        calculateFare(rides, Fare.FareType.youth, 305f);
+        calculateFare(rides, Fare.FareType.youth, 0f);
         calculateFare(rides, Fare.FareType.electronicSpecial, 610f);
         calculateFare(rides, Fare.FareType.electronicRegular, 610f);
         calculateFare(rides, Fare.FareType.electronicSenior, 305f);
-        calculateFare(rides, Fare.FareType.electronicYouth, 305f);
+        calculateFare(rides, Fare.FareType.electronicYouth, 0f);
     }
 
     /**
@@ -252,22 +252,22 @@ public class OrcaFareServiceTest {
         );
         calculateFare(rides, Fare.FareType.regular, 250f);
         calculateFare(rides, Fare.FareType.senior, 100f);
-        calculateFare(rides, Fare.FareType.youth, 150f);
+        calculateFare(rides, Fare.FareType.youth, 0f);
         calculateFare(rides, Fare.FareType.electronicSpecial, 150f);
         calculateFare(rides, Fare.FareType.electronicRegular, 250f);
         calculateFare(rides, Fare.FareType.electronicSenior, 100f);
-        calculateFare(rides, Fare.FareType.electronicYouth, 150f);
+        calculateFare(rides, Fare.FareType.electronicYouth, 0f);
         // Ensure that it works in reverse
         rides = Collections.singletonList(
             getRide(SOUND_TRANSIT_AGENCY_ID, "1-Line", 0, "Int'l Dist/Chinatown", "Roosevelt Station")
         );
         calculateFare(rides, Fare.FareType.regular, 250f);
         calculateFare(rides, Fare.FareType.senior, 100f);
-        calculateFare(rides, Fare.FareType.youth, 150f);
+        calculateFare(rides, Fare.FareType.youth, 0f);
         calculateFare(rides, Fare.FareType.electronicSpecial, 150f);
         calculateFare(rides, Fare.FareType.electronicRegular, 250f);
         calculateFare(rides, Fare.FareType.electronicSenior, 100f);
-        calculateFare(rides, Fare.FareType.electronicYouth, 150f);
+        calculateFare(rides, Fare.FareType.electronicYouth, 0f);
     }
 
     @Test
@@ -277,22 +277,22 @@ public class OrcaFareServiceTest {
         );
         calculateFare(rides, Fare.FareType.regular, 425f);
         calculateFare(rides, Fare.FareType.senior, 100f);
-        calculateFare(rides, Fare.FareType.youth, 150f);
+        calculateFare(rides, Fare.FareType.youth, 0f);
         calculateFare(rides, Fare.FareType.electronicSpecial, 150f);
         calculateFare(rides, Fare.FareType.electronicRegular, 425f);
         calculateFare(rides, Fare.FareType.electronicSenior, 100f);
-        calculateFare(rides, Fare.FareType.electronicYouth, 150f);
+        calculateFare(rides, Fare.FareType.electronicYouth, 0f);
         // Ensure that it works in reverse
         rides = Collections.singletonList(
             getRide(SOUND_TRANSIT_AGENCY_ID, "N Line", 0, "King Street Station", "Everett Station")
         );
         calculateFare(rides, Fare.FareType.regular, 500f);
         calculateFare(rides, Fare.FareType.senior, 100f);
-        calculateFare(rides, Fare.FareType.youth, 150f);
+        calculateFare(rides, Fare.FareType.youth, 0f);
         calculateFare(rides, Fare.FareType.electronicSpecial, 150f);
         calculateFare(rides, Fare.FareType.electronicRegular, 500f);
         calculateFare(rides, Fare.FareType.electronicSenior, 100f);
-        calculateFare(rides, Fare.FareType.electronicYouth, 150f);
+        calculateFare(rides, Fare.FareType.electronicYouth, 0f);
     }
 
     /**
@@ -309,11 +309,11 @@ public class OrcaFareServiceTest {
         );
         calculateFare(rides, Fare.FareType.regular, 975f);
         calculateFare(rides, Fare.FareType.senior, 300f);
-        calculateFare(rides, Fare.FareType.youth, 450f);
+        calculateFare(rides, Fare.FareType.youth, 0f);
         calculateFare(rides, Fare.FareType.electronicSpecial, 450f);
         calculateFare(rides, Fare.FareType.electronicRegular, 975f);
         calculateFare(rides, Fare.FareType.electronicSenior, 300f);
-        calculateFare(rides, Fare.FareType.electronicYouth, 450f);
+        calculateFare(rides, Fare.FareType.electronicYouth, 0f);
 
         // Also make sure that PT's 500 and 501 get regular Pierce fare and not ST's fare
         rides = Arrays.asList(
@@ -322,11 +322,11 @@ public class OrcaFareServiceTest {
         );
         calculateFare(rides, Fare.FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS * 2);
         calculateFare(rides, Fare.FareType.senior, DEFAULT_RIDE_PRICE_IN_CENTS * 2);
-        calculateFare(rides, Fare.FareType.youth, 200f);
+        calculateFare(rides, Fare.FareType.youth, 0f);
         calculateFare(rides, Fare.FareType.electronicSpecial, DEFAULT_RIDE_PRICE_IN_CENTS);
         calculateFare(rides, Fare.FareType.electronicRegular, DEFAULT_RIDE_PRICE_IN_CENTS);
         calculateFare(rides, Fare.FareType.electronicSenior, 100f);
-        calculateFare(rides, Fare.FareType.electronicYouth, 100f);
+        calculateFare(rides, Fare.FareType.electronicYouth, 0f);
     }
 
     @Test
@@ -340,11 +340,11 @@ public class OrcaFareServiceTest {
         );
         calculateFare(rides, Fare.FareType.regular, DEFAULT_RIDE_PRICE_IN_CENTS * 3);
         calculateFare(rides, Fare.FareType.senior, 325f);
-        calculateFare(rides, Fare.FareType.youth, 475f);
+        calculateFare(rides, Fare.FareType.youth, 0f);
         calculateFare(rides, Fare.FareType.electronicSpecial, 300f);
         calculateFare(rides, Fare.FareType.electronicRegular, DEFAULT_RIDE_PRICE_IN_CENTS * 2);
         calculateFare(rides, Fare.FareType.electronicSenior, 125f); // Transfer extended by CT ride
-        calculateFare(rides, Fare.FareType.electronicYouth, 175f); // Transfer extended by CT ride
+        calculateFare(rides, Fare.FareType.electronicYouth, 0f);
     }
 
     @Test
@@ -356,11 +356,11 @@ public class OrcaFareServiceTest {
         );
         calculateFare(rides, Fare.FareType.regular, 250f+325f+300f);
         calculateFare(rides, Fare.FareType.senior, 100f*3);
-        calculateFare(rides, Fare.FareType.youth, 150f*3);
+        calculateFare(rides, Fare.FareType.youth, 0f);
         calculateFare(rides, Fare.FareType.electronicSpecial, 150f*2);
         calculateFare(rides, Fare.FareType.electronicRegular, 325f); // transfer extended on second leg
         calculateFare(rides, Fare.FareType.electronicSenior, 100f*2);
-        calculateFare(rides, Fare.FareType.electronicYouth, 150f*2);
+        calculateFare(rides, Fare.FareType.electronicYouth, 0f);
 
     }
 


### PR DESCRIPTION
This PR makes youth fares free for ORCA region. It fixes the relevant transfer rules as well so that free fares don't show as needing transfers on the fare-by-leg table. Tests are updated as well.

- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
