### PR TITLE
Add fare smoke tests for some deployments

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -29,7 +29,7 @@ jobs:
             sleep: 15
           - name: portland
             # have to sleep longer since computing geofencing zones takes a while
-            sleep: 80
+            sleep: 125
 
     steps:
       - uses: actions/checkout@v3

--- a/pom.xml
+++ b/pom.xml
@@ -987,7 +987,7 @@
         <dependency>
             <groupId>org.opentripplanner</groupId>
             <artifactId>otp-client</artifactId>
-            <version>0.0.10</version>
+            <version>0.0.14</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/smoke-tests/denver/router-config.json
+++ b/smoke-tests/denver/router-config.json
@@ -3,8 +3,7 @@
     {
       "type": "vehicle-positions",
       "url": "https://www.rtd-denver.com/files/gtfs-rt/VehiclePosition.pb",
-      "feedId": "denver",
-      "frequencySec": 60
+      "feedId": "denver"
     }
   ]
 }

--- a/smoke-tests/portland/otp-config.json
+++ b/smoke-tests/portland/otp-config.json
@@ -1,5 +1,4 @@
 {
   "otpFeatures" : {
-    "SandboxAPILegacyGraphQLApi": true
   }
 }

--- a/smoke-tests/portland/router-config.json
+++ b/smoke-tests/portland/router-config.json
@@ -19,6 +19,13 @@
       "sourceType": "gbfs",
       "url": "https://mds.bird.co/gbfs/v2/public/portland/gbfs.json",
       "geofencingZones": "true"
+    },
+    {
+      "type": "vehicle-rental",
+      "frequency": "90s",
+      "sourceType": "gbfs",
+      "url": "https://gbfs.spin.pm/api/gbfs/v2_3/portland/gbfs",
+      "geofencingZones": "true"
     }
   ]
 }

--- a/smoke-tests/portland/router-config.json
+++ b/smoke-tests/portland/router-config.json
@@ -3,20 +3,19 @@
   "updaters": [
     {
       "type": "real-time-alerts",
-      "frequencySec": 60,
       "earlyStartSec": 864000,
       "url": "https://trimet.org/transweb/ws/V1/FeedSpecAlerts/includeFuture/true/suppressSystemWideAlerts/true/",
       "feedId": "TriMet"
     },
     {
       "type": "stop-time-updater",
-      "frequencySec": 30,
+      "frequency": "30s",
       "url": "https://trimet.org/transweb/ws/V1/TripUpdate",
       "feedId": "TriMet"
     },
     {
       "type": "vehicle-rental",
-      "frequencySec": 90,
+      "frequency": "90s",
       "sourceType": "gbfs",
       "url": "https://mds.bird.co/gbfs/v2/public/portland/gbfs.json",
       "geofencingZones": "true"

--- a/smoke-tests/septa/otp-config.json
+++ b/smoke-tests/septa/otp-config.json
@@ -1,5 +1,4 @@
 {
   "otpFeatures" : {
-    "SandboxAPILegacyGraphQLApi": true
   }
 }

--- a/src/test/java/org/opentripplanner/smoketest/HoustonSmokeTest.java
+++ b/src/test/java/org/opentripplanner/smoketest/HoustonSmokeTest.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.smoketest;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.opentripplanner.client.model.RequestMode.BICYCLE;
 import static org.opentripplanner.client.model.RequestMode.BUS;
 import static org.opentripplanner.client.model.RequestMode.TRANSIT;
@@ -33,7 +32,7 @@ public class HoustonSmokeTest {
       List.of("WALK", "BUS", "BUS", "WALK", "TRAM", "WALK")
     );
 
-    SmokeTest.assertThatAllTransitLegsHaveFares(plan);
+    SmokeTest.assertThatAllTransitLegsHaveFareProducts(plan);
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/smoketest/HoustonSmokeTest.java
+++ b/src/test/java/org/opentripplanner/smoketest/HoustonSmokeTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.smoketest;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.opentripplanner.client.model.RequestMode.BICYCLE;
 import static org.opentripplanner.client.model.RequestMode.BUS;
 import static org.opentripplanner.client.model.RequestMode.TRANSIT;
@@ -27,10 +28,12 @@ public class HoustonSmokeTest {
   @Test
   public void routeFromSouthToNorth() {
     var modes = Set.of(TRANSIT, WALK);
-    SmokeTest.basicRouteTest(
+    var plan = SmokeTest.basicRouteTest(
       new SmokeTestRequest(galvestonRoad, northLindale, modes),
       List.of("WALK", "BUS", "BUS", "WALK", "TRAM", "WALK")
     );
+
+    SmokeTest.assertThatAllTransitLegsHaveFares(plan);
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/smoketest/PortlandSmokeTest.java
+++ b/src/test/java/org/opentripplanner/smoketest/PortlandSmokeTest.java
@@ -32,7 +32,7 @@ public class PortlandSmokeTest {
       List.of("WALK", "TRAM", "WALK")
     );
 
-    SmokeTest.assertThatAllTransitLegsHaveFares(plan);
+    SmokeTest.assertThatAllTransitLegsHaveFareProducts(plan);
   }
 
   /**

--- a/src/test/java/org/opentripplanner/smoketest/PortlandSmokeTest.java
+++ b/src/test/java/org/opentripplanner/smoketest/PortlandSmokeTest.java
@@ -27,10 +27,12 @@ public class PortlandSmokeTest {
   public void railTrip() {
     // this used to be across the city by since the train is interrupted in April '23 this is a
     // much shorter trip
-    SmokeTest.basicRouteTest(
+    var plan = SmokeTest.basicRouteTest(
       new SmokeTestRequest(cennentenial, hazelwood, Set.of(TRAM, WALK)),
       List.of("WALK", "TRAM", "WALK")
     );
+
+    SmokeTest.assertThatAllTransitLegsHaveFares(plan);
   }
 
   /**

--- a/src/test/java/org/opentripplanner/smoketest/SeptaSmokeTest.java
+++ b/src/test/java/org/opentripplanner/smoketest/SeptaSmokeTest.java
@@ -1,15 +1,21 @@
 package org.opentripplanner.smoketest;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.client.model.RequestMode.BICYCLE_RENT;
 import static org.opentripplanner.client.model.RequestMode.TRANSIT;
 import static org.opentripplanner.client.model.RequestMode.WALK;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.client.model.Coordinate;
+import org.opentripplanner.client.model.TripPlan.FareProductUse;
 import org.opentripplanner.smoketest.util.SmokeTestRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This smoke test expects an OTP installation running at localhost:8080
@@ -17,6 +23,8 @@ import org.opentripplanner.smoketest.util.SmokeTestRequest;
 @Tag("smoke-test")
 @Tag("septa")
 public class SeptaSmokeTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SeptaSmokeTest.class);
 
   Coordinate airport = new Coordinate(39.876151, -75.245189);
   Coordinate stPetersCemetary = new Coordinate(39.98974, -75.09515);
@@ -27,10 +35,25 @@ public class SeptaSmokeTest {
   @Test
   public void routeFromAirportToNorthPhiladelphia() {
     var modes = Set.of(TRANSIT, WALK);
-    SmokeTest.basicRouteTest(
+    var plan = SmokeTest.basicRouteTest(
       new SmokeTestRequest(airport, stPetersCemetary, modes),
       List.of("WALK", "RAIL", "RAIL", "WALK", "SUBWAY", "WALK")
     );
+    var products = plan
+      .itineraries()
+      .stream()
+      .flatMap(i -> i.legs().stream())
+      .flatMap(leg -> leg.fareProducts().stream())
+      .map(FareProductUse::product)
+      .toList();
+
+    assertFalse(products.isEmpty());
+
+    var prices = products.stream().map(p -> p.price().amount().doubleValue()).collect(Collectors.toSet());
+
+    LOG.info("Received fare products {}", products);
+
+    assertTrue(prices.contains(2.5d));
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/smoketest/SeptaSmokeTest.java
+++ b/src/test/java/org/opentripplanner/smoketest/SeptaSmokeTest.java
@@ -49,7 +49,10 @@ public class SeptaSmokeTest {
 
     assertFalse(products.isEmpty());
 
-    var prices = products.stream().map(p -> p.price().amount().doubleValue()).collect(Collectors.toSet());
+    var prices = products
+      .stream()
+      .map(p -> p.price().amount().doubleValue())
+      .collect(Collectors.toSet());
 
     LOG.info("Received fare products {}", products);
 

--- a/src/test/java/org/opentripplanner/smoketest/SmokeTest.java
+++ b/src/test/java/org/opentripplanner/smoketest/SmokeTest.java
@@ -135,6 +135,11 @@ public class SmokeTest {
     }
   }
 
+  static void assertThatAllTransitLegsHaveFares(TripPlan plan) {
+    var transitLegs = plan.transitItineraries().stream().flatMap(i-> i.transitLegs().stream());
+    transitLegs.forEach(leg -> assertFalse(leg.fareProducts().isEmpty()));
+  }
+
   /**
    * The Fare class is a little hard to deserialize, so we have a custom deserializer as we don't
    * run any assertions against the fares. (That is done during unit tests.)

--- a/src/test/java/org/opentripplanner/smoketest/SmokeTest.java
+++ b/src/test/java/org/opentripplanner/smoketest/SmokeTest.java
@@ -135,7 +135,7 @@ public class SmokeTest {
     }
   }
 
-  static void assertThatAllTransitLegsHaveFares(TripPlan plan) {
+  static void assertThatAllTransitLegsHaveFareProducts(TripPlan plan) {
     var transitLegs = plan.transitItineraries().stream().flatMap(i -> i.transitLegs().stream());
     transitLegs.forEach(leg -> assertFalse(leg.fareProducts().isEmpty()));
   }

--- a/src/test/java/org/opentripplanner/smoketest/SmokeTest.java
+++ b/src/test/java/org/opentripplanner/smoketest/SmokeTest.java
@@ -136,7 +136,7 @@ public class SmokeTest {
   }
 
   static void assertThatAllTransitLegsHaveFares(TripPlan plan) {
-    var transitLegs = plan.transitItineraries().stream().flatMap(i-> i.transitLegs().stream());
+    var transitLegs = plan.transitItineraries().stream().flatMap(i -> i.transitLegs().stream());
     transitLegs.forEach(leg -> assertFalse(leg.fareProducts().isEmpty()));
   }
 

--- a/src/test/java/org/opentripplanner/smoketest/SmokeTest.java
+++ b/src/test/java/org/opentripplanner/smoketest/SmokeTest.java
@@ -3,14 +3,6 @@ package org.opentripplanner.smoketest;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import java.io.IOException;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -18,14 +10,11 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
-import org.opentripplanner.api.json.JSONObjectMapperProvider;
-import org.opentripplanner.api.resource.DebugOutput;
 import org.opentripplanner.client.OtpApiClient;
 import org.opentripplanner.client.model.TripPlan;
 import org.opentripplanner.client.model.TripPlan.Itinerary;
 import org.opentripplanner.client.model.VehicleRentalStation;
 import org.opentripplanner.client.parameters.TripPlanParameters;
-import org.opentripplanner.model.fare.ItineraryFares;
 import org.opentripplanner.smoketest.util.SmokeTestRequest;
 
 /**
@@ -38,24 +27,10 @@ import org.opentripplanner.smoketest.util.SmokeTestRequest;
  */
 public class SmokeTest {
 
-  public static final ObjectMapper mapper;
   public static final OtpApiClient API_CLIENT = new OtpApiClient(
     ZoneId.of("America/New_York"),
     "http://localhost:8080"
   );
-
-  static {
-    var provider = new JSONObjectMapperProvider();
-
-    SimpleModule module = new SimpleModule("SmokeTests");
-    module.addDeserializer(ItineraryFares.class, new FareDeserializer());
-    module.addDeserializer(DebugOutput.class, new DebugOutputDeserializer());
-
-    mapper = provider.getContext(null);
-    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    mapper.registerModule(new ParameterNamesModule(JsonCreator.Mode.PROPERTIES));
-    mapper.registerModule(module);
-  }
 
   /**
    * In order to have somewhat predictable results we get the route for the next Monday.
@@ -138,31 +113,5 @@ public class SmokeTest {
   static void assertThatAllTransitLegsHaveFareProducts(TripPlan plan) {
     var transitLegs = plan.transitItineraries().stream().flatMap(i -> i.transitLegs().stream());
     transitLegs.forEach(leg -> assertFalse(leg.fareProducts().isEmpty()));
-  }
-
-  /**
-   * The Fare class is a little hard to deserialize, so we have a custom deserializer as we don't
-   * run any assertions against the fares. (That is done during unit tests.)
-   */
-  static class FareDeserializer extends JsonDeserializer<ItineraryFares> {
-
-    @Override
-    public ItineraryFares deserialize(
-      JsonParser jsonParser,
-      DeserializationContext deserializationContext
-    ) {
-      return null;
-    }
-  }
-
-  static class DebugOutputDeserializer extends JsonDeserializer<DebugOutput> {
-
-    @Override
-    public DebugOutput deserialize(
-      JsonParser jsonParser,
-      DeserializationContext deserializationContext
-    ) {
-      return null;
-    }
   }
 }


### PR DESCRIPTION
After the ST fares debacle I'm adding checks that fares are correctly returned to the smoke tests.

This PR includes tests for Portland, Septa and Houston. More will come later when those calculators are fixed.