### PR TITLE
Add assertions for complex CCSWW flex zones

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -49,9 +49,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: smoke-tests/**/*.pbf
-          key: osm-${{ matrix.locations.name }}-2023-02-22
-          restore-keys: |
-            osm-${{ matrix.locations.name }}
+          key: osm-${{ matrix.locations.name }}-2023-10-31
 
       - name: Build graph
         working-directory: smoke-tests

--- a/pom.xml
+++ b/pom.xml
@@ -982,7 +982,7 @@
         <dependency>
             <groupId>org.opentripplanner</groupId>
             <artifactId>otp-client</artifactId>
-            <version>0.0.16</version>
+            <version>0.0.20</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/smoke-tests/Makefile
+++ b/smoke-tests/Makefile
@@ -19,7 +19,7 @@ portland/osm.pbf:
 	${CURL} http://osm.ibi-transit.com/vex/45.424388,-122.885443,45.684746,-122.44084.pbf -o $@
 
 seattle/osm.pbf:
-	${CURL} http://osm.ibi-transit.com/vex/47.481002,-122.459681,47.734124,-122.224433.pbf -o $@
+	${CURL} http://osm.ibi-transit.com/vex/47.50925,-122.47458,47.786105,-122.224433.pbf -o $@
 
 build-%: otp.jar %/osm.pbf
 	java -Xmx6G -jar otp.jar --build --save $*

--- a/smoke-tests/seattle/build-config.json
+++ b/smoke-tests/seattle/build-config.json
@@ -14,6 +14,11 @@
     },
     {
       "type" : "gtfs",
+      "feedId" : "ccsww-nw",
+      "source" : "https://data.trilliumtransit.com/gtfs/catholiccommunity-wa-us/catholiccommunity-wa-us-northwest--flex-v2.zip"
+    },
+    {
+      "type" : "gtfs",
       "feedId" : "payyourpal",
       "source" : "https://data.trilliumtransit.com/gtfs/homage-wa-us/homage-wa-us-payyourpal--flex-v2.zip"
     },

--- a/src/test/java/org/opentripplanner/smoketest/AtlantaSmokeTest.java
+++ b/src/test/java/org/opentripplanner/smoketest/AtlantaSmokeTest.java
@@ -61,7 +61,7 @@ public class AtlantaSmokeTest {
 
     var usesZone1Route = transitLegs
       .stream()
-      .map(l -> l.route().shortName())
+      .map(l -> l.route().name())
       .anyMatch(name -> name.equals("Zone 1"));
 
     assertTrue(usesZone1Route);

--- a/src/test/java/org/opentripplanner/smoketest/SeattleSmokeTest.java
+++ b/src/test/java/org/opentripplanner/smoketest/SeattleSmokeTest.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.client.model.Coordinate;
+import org.opentripplanner.client.model.LegMode;
 import org.opentripplanner.client.model.Route;
 import org.opentripplanner.smoketest.util.SmokeTestRequest;
 
@@ -23,11 +24,14 @@ import org.opentripplanner.smoketest.util.SmokeTestRequest;
 @Tag("seattle")
 public class SeattleSmokeTest {
 
+  private static final String CCSWW_ROUTE = "Volunteer Services: Northwest";
   Coordinate sodo = new Coordinate(47.5811, -122.3290);
   Coordinate clydeHill = new Coordinate(47.6316, -122.2173);
 
-  Coordinate boeingCreekPark = new Coordinate(47.755872, -122.361645);
   Coordinate ronaldBogPark = new Coordinate(47.75601664, -122.33141);
+
+  Coordinate esperance = new Coordinate(47.7957, -122.3470);
+  Coordinate shoreline = new Coordinate(47.7568, -122.3483);
 
   @Test
   public void acrossTheCity() {
@@ -43,14 +47,44 @@ public class SeattleSmokeTest {
   @Test
   public void flexAndTransit() {
     var modes = Set.of(WALK, BUS, FLEX_DIRECT, FLEX_EGRESS, FLEX_ACCESS);
-    SmokeTest.basicRouteTest(
-      new SmokeTestRequest(boeingCreekPark, ronaldBogPark, modes),
-      List.of("BUS")
-    );
+    SmokeTest.basicRouteTest(new SmokeTestRequest(shoreline, ronaldBogPark, modes), List.of("BUS"));
   }
 
   @Test
-  public void monorailRoute() throws IOException, InterruptedException {
+  public void ccswwIntoKingCounty() {
+    var modes = Set.of(WALK, FLEX_DIRECT);
+    var plan = SmokeTest.basicRouteTest(
+      new SmokeTestRequest(esperance, shoreline, modes),
+      List.of("BUS")
+    );
+    var itin = plan.itineraries().get(0);
+    var flexLeg = itin.transitLegs().get(0);
+    assertEquals(CCSWW_ROUTE, flexLeg.route().name());
+    assertEquals(CCSWW_ROUTE, flexLeg.route().agency().name());
+  }
+
+  @Test
+  public void ccswwIntoSnohomishCounty() {
+    var modes = Set.of(WALK, FLEX_DIRECT);
+    var plan = SmokeTest.basicRouteTest(
+      new SmokeTestRequest(shoreline, esperance, modes),
+      List.of("BUS", "WALK")
+    );
+    var walkAndFlex = plan
+      .transitItineraries()
+      .stream()
+      .filter(i -> i.transitLegs().stream().anyMatch(l -> l.route().name().equals(CCSWW_ROUTE)))
+      .findFirst()
+      .get();
+    assertEquals(2, walkAndFlex.legs().size());
+    // walk to the border of King County
+    assertEquals(LegMode.WALK, walkAndFlex.legs().get(0).mode());
+    // and take flex inside Snohomish County to the destination
+    assertEquals(LegMode.BUS, walkAndFlex.legs().get(1).mode());
+  }
+
+  @Test
+  public void monorailRoute() throws IOException {
     Set<Object> modes = SmokeTest.API_CLIENT
       .routes()
       .stream()

--- a/src/test/java/org/opentripplanner/smoketest/SmokeTest.java
+++ b/src/test/java/org/opentripplanner/smoketest/SmokeTest.java
@@ -55,7 +55,7 @@ public class SmokeTest {
     try {
       List<VehicleRentalStation> stations = API_CLIENT.vehicleRentalStations();
       assertFalse(stations.isEmpty(), "Found no vehicle rental stations.");
-    } catch (IOException | InterruptedException e) {
+    } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }
@@ -96,7 +96,7 @@ public class SmokeTest {
 
       assertThatItineraryHasModes(itineraries, expectedModes);
       return plan;
-    } catch (InterruptedException | IOException e) {
+    } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }
@@ -110,7 +110,7 @@ public class SmokeTest {
         vehiclePositions.isEmpty(),
         "Found no patterns that have realtime vehicle positions."
       );
-    } catch (IOException | InterruptedException e) {
+    } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }


### PR DESCRIPTION
Recently we merged a PR for support for the (comparatively) complex CCSWW feed.

Since this has a few moving parts, I added a smoke test to check that the results are returned as expected.