### PR TITLE
[DO NOT MERGE] PRs to test during Leonard's absence

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,7 +12,7 @@
         "bootstrap": "5.3.3",
         "graphql": "16.9.0",
         "graphql-request": "7.1.0",
-        "maplibre-gl": "4.5.0",
+        "maplibre-gl": "4.5.1",
         "react": "18.3.1",
         "react-bootstrap": "2.10.4",
         "react-dom": "18.3.1",
@@ -40,7 +40,7 @@
         "jsdom": "24.1.1",
         "prettier": "3.3.3",
         "typescript": "5.5.4",
-        "vite": "5.3.5",
+        "vite": "5.4.0",
         "vitest": "2.0.5"
       }
     },
@@ -3846,11 +3846,6 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
-    "node_modules/@types/junit-report-builder": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/junit-report-builder/-/junit-report-builder-3.0.2.tgz",
-      "integrity": "sha512-R5M+SYhMbwBeQcNXYWNCZkl09vkVfAtcPIaCGdzIkkbeaTrVbGQ7HVgi4s+EmM/M1K4ZuWQH0jGcvMvNePfxYA=="
-    },
     "node_modules/@types/mapbox__point-geometry": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
@@ -5701,9 +5696,10 @@
       }
     },
     "node_modules/earcut": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.0.tgz",
+      "integrity": "sha512-41Fs7Q/PLq1SDbqjsgcY7GA42T0jvaCNGXgGtsNdvg+Yv8eIu06bxv4/PoREkZ9nMDNwnUSG9OFB9+yv8eKhDg==",
+      "license": "ISC"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -8731,9 +8727,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.5.0.tgz",
-      "integrity": "sha512-qOS1hn4d/pn2i0uva4S5Oz+fACzTkgBKq+NpwT/Tqzi4MSyzcWNtDELzLUSgWqHfNIkGCl5CZ/w7dtis+t4RCw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.5.1.tgz",
+      "integrity": "sha512-pKFDK8ZU2atwZWC8gdPVhN7Bf5HIPgtA+IG/iQ7J6WgmqSwCSmylc5q3stahWqXfx9PYUwVNJITrp1Hw96SUiA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
@@ -8746,22 +8742,21 @@
         "@maplibre/maplibre-gl-style-spec": "^20.3.0",
         "@types/geojson": "^7946.0.14",
         "@types/geojson-vt": "3.2.5",
-        "@types/junit-report-builder": "^3.0.2",
         "@types/mapbox__point-geometry": "^0.1.4",
         "@types/mapbox__vector-tile": "^1.3.4",
         "@types/pbf": "^3.0.5",
         "@types/supercluster": "^7.1.3",
-        "earcut": "^2.2.4",
+        "earcut": "^3.0.0",
         "geojson-vt": "^4.0.2",
         "gl-matrix": "^3.4.3",
         "global-prefix": "^3.0.0",
         "kdbush": "^4.0.2",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
+        "pbf": "^3.3.0",
         "potpack": "^2.0.0",
-        "quickselect": "^2.0.0",
+        "quickselect": "^3.0.0",
         "supercluster": "^8.0.1",
-        "tinyqueue": "^2.0.3",
+        "tinyqueue": "^3.0.0",
         "vt-pbf": "^3.1.3"
       },
       "engines": {
@@ -8771,6 +8766,18 @@
       "funding": {
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
+    },
+    "node_modules/maplibre-gl/node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
+    "node_modules/maplibre-gl/node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -9495,9 +9502,10 @@
       }
     },
     "node_modules/pbf": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
-      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
@@ -11392,14 +11400,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.5.tgz",
-      "integrity": "sha512-MdjglKR6AQXQb9JGiS7Rc2wC6uMjcm7Go/NHNO63EwiJXfuk9PgqiP/n5IDJCziMkfw9n4Ubp7lttNwz+8ZVKA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.0.tgz",
+      "integrity": "sha512-5xokfMX0PIiwCMCMb9ZJcMyh5wbBun0zUzKib+L65vAZ8GY9ePZMXxFrHbr/Kyll2+LSCY7xtERPpxkBDKngwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
-        "postcss": "^8.4.39",
+        "postcss": "^8.4.40",
         "rollup": "^4.13.0"
       },
       "bin": {
@@ -11419,6 +11427,7 @@
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
+        "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
         "terser": "^5.4.0"
@@ -11434,6 +11443,9 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
           "optional": true
         },
         "stylus": {

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "bootstrap": "5.3.3",
     "graphql": "16.9.0",
     "graphql-request": "7.1.0",
-    "maplibre-gl": "4.5.0",
+    "maplibre-gl": "4.5.1",
     "react": "18.3.1",
     "react-bootstrap": "2.10.4",
     "react-dom": "18.3.1",
@@ -49,7 +49,7 @@
     "jsdom": "24.1.1",
     "prettier": "3.3.3",
     "typescript": "5.5.4",
-    "vite": "5.3.5",
+    "vite": "5.4.0",
     "vitest": "2.0.5"
   }
 }

--- a/docs/examples/ibi/portland/router-config.json
+++ b/docs/examples/ibi/portland/router-config.json
@@ -59,6 +59,61 @@
       "url": "https://gbfs.spin.pm/api/gbfs/v2/portland"
     }
   ],
+  "vectorTiles": {
+    "basePath": "/rtp/routers/default/vectorTiles",
+    "attribution": "<a href='https://trimet.org/mod'>Regional Partners</a>",
+    "layers": [
+      {
+        "name": "stops",
+        "type": "CurrentServiceWeekStop",
+        "mapper": "Digitransit",
+        "maxZoom": 20,
+        "minZoom": 14,
+        "cacheMaxSeconds": 600
+      },
+      {
+        "name": "areaStops",
+        "type": "AreaStop",
+        "mapper": "OTPRR",
+        "maxZoom": 30,
+        "minZoom":  8,
+        "cacheMaxSeconds": 600
+      },
+      {
+        "name": "stations",
+        "type": "Station",
+        "mapper": "Digitransit",
+        "maxZoom": 20,
+        "minZoom": 2,
+        "cacheMaxSeconds": 600
+      },
+      {
+        "name": "rentalVehicles",
+        "type": "VehicleRentalVehicle",
+        "mapper": "Digitransit",
+        "maxZoom": 20,
+        "minZoom": 2,
+        "cacheMaxSeconds": 60
+      },
+      {
+        "name": "rentalStations",
+        "type": "VehicleRentalStation",
+        "mapper": "Digitransit",
+        "maxZoom": 20,
+        "minZoom": 2,
+        "cacheMaxSeconds": 600
+      },
+      {
+        "name": "vehicleParking",
+        "type": "VehicleParking",
+        "mapper": "Digitransit",
+        "maxZoom": 20,
+        "minZoom": 10,
+        "cacheMaxSeconds": 60,
+        "expansionFactor": 0.25
+      }
+    ]
+  },
   "rideHailingServices": [
     {
       "type": "uber-car-hailing",

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <netcdf4.version>5.6.0</netcdf4.version>
         <logback.version>1.5.6</logback.version>
         <lucene.version>9.11.1</lucene.version>
-        <slf4j.version>2.0.13</slf4j.version>
+        <slf4j.version>2.0.14</slf4j.version>
         <netex-java-model.version>2.0.15</netex-java-model.version>
         <siri-java-model.version>1.27</siri-java-model.version>
         <jaxb-runtime.version>4.0.5</jaxb-runtime.version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <geotools.version>31.3</geotools.version>
         <google.dagger.version>2.51.1</google.dagger.version>
         <jackson.version>2.17.2</jackson.version>
-        <jersey.version>3.1.7</jersey.version>
+        <jersey.version>3.1.8</jersey.version>
         <junit.version>5.10.3</junit.version>
         <micrometer.version>1.13.2</micrometer.version>
         <netcdf4.version>5.6.0</netcdf4.version>

--- a/pom.xml
+++ b/pom.xml
@@ -546,7 +546,7 @@
                 <!-- This make sure all google libraries are using compatible versions. -->
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>26.40.0</version>
+                <version>26.44.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -577,7 +577,7 @@
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
-            <version>7.4</version>
+            <version>8.0</version>
         </dependency>
 
         <!-- dependency injection -->

--- a/renovate.json5
+++ b/renovate.json5
@@ -74,7 +74,6 @@
       "description": "Automerge Maven plugins in a single PR",
       "groupName": "Maven plugins",
       "matchPackageNames": [
-        "ch.qos.logback:logback-classic",
         "io.github.git-commit-id:git-commit-id-maven-plugin",
         "org.apache.maven.plugins:maven-gpg-plugin",
         "org.codehaus.mojo:build-helper-maven-plugin",
@@ -124,7 +123,7 @@
       ]
     },
     {
-      "groupName": "Automerge mkdocs in a single PR",
+      "groupName": "mkdocs",
       "description": "automerge mkdocs-material every quarter",
       "matchPackageNames": [
         "mkdocs",
@@ -136,12 +135,14 @@
       "automerge": true
     },
     {
-      "description": "automatically merge slf4j",
+      "description": "Automerge logging dependencies in a single PR",
+      "groupName": "logging",
       "matchPackagePrefixes": [
-        "org.slf4j:"
+        "org.slf4j:",
+        "ch.qos.logback:"
       ],
       "automerge": true,
-      "schedule": "after 11pm and before 5am every weekday"
+      "schedule": "on the 4th day of the month"
     },
     {
       "description": "give some projects time to publish a changelog before opening the PR",

--- a/renovate.json5
+++ b/renovate.json5
@@ -34,7 +34,7 @@
       "matchFiles": ["client/package.json"],
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "Debug UI dependencies (non-major)",
-      "schedule": ["on the first day of the week"],
+      "schedule": ["on the 3rd and 17th day of the month"],
       "reviewers": ["testower"]
     },
     {
@@ -45,6 +45,8 @@
     // some dependencies that we auto-merge release very often and even the auto-merges create a lot of
     // noise, so we slow it down a bit
     {
+      "description": "Automerge test dependencies in a single PR",
+      "groupName": "Test dependencies",
       "matchPackageNames": [
         "org.mockito:mockito-core",
         "com.tngtech.archunit:archunit",
@@ -57,7 +59,6 @@
       "matchPackagePrefixes": [
         "org.junit.jupiter:",
       ],
-      "groupName": "Test dependencies",
       "automerge": true,
       "schedule": "on the 17th day of the month"
     },
@@ -70,12 +71,22 @@
       "automerge": true
     },
     {
+      "description": "Automerge Maven plugins in a single PR",
+      "groupName": "Maven plugins",
       "matchPackageNames": [
         "ch.qos.logback:logback-classic",
         "io.github.git-commit-id:git-commit-id-maven-plugin",
-        "org.apache.maven.plugins:maven-gpg-plugin"
+        "org.apache.maven.plugins:maven-gpg-plugin",
+        "org.codehaus.mojo:build-helper-maven-plugin",
+        "org.apache.maven.plugins:maven-source-plugin",
+        "com.hubspot.maven.plugins:prettier-maven-plugin",
+        "com.google.cloud.tools:jib-maven-plugin",
+        "org.apache.maven.plugins:maven-shade-plugin",
+        "org.apache.maven.plugins:maven-compiler-plugin",
+        "org.apache.maven.plugins:maven-jar-plugin",
+        "org.sonatype.plugins:nexus-staging-maven-plugin"
       ],
-      "schedule": "on the 19th day of the month",
+      "schedule": "on the 23rd day of the month",
       "automerge": true
     },
     {
@@ -125,18 +136,7 @@
       "automerge": true
     },
     {
-      "description": "automatically merge test, logging and build dependencies",
-      "matchPackageNames": [
-        // maven plugins
-        "org.codehaus.mojo:build-helper-maven-plugin",
-        "org.apache.maven.plugins:maven-source-plugin",
-        "com.hubspot.maven.plugins:prettier-maven-plugin",
-        "com.google.cloud.tools:jib-maven-plugin",
-        "org.apache.maven.plugins:maven-shade-plugin",
-        "org.apache.maven.plugins:maven-compiler-plugin",
-        "org.apache.maven.plugins:maven-jar-plugin",
-        "org.sonatype.plugins:nexus-staging-maven-plugin"
-      ],
+      "description": "automatically merge slf4j",
       "matchPackagePrefixes": [
         "org.slf4j:"
       ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -103,17 +103,16 @@
         "org.onebusaway:onebusaway-gtfs",
         "com.google.cloud:libraries-bom",
         "com.google.guava:guava",
-        "@graphql-codegen/add",
-        "@graphql-codegen/cli",
-        "@graphql-codegen/java",
-        "@graphql-codegen/java-resolvers",
-        "graphql",
         "io.micrometer:micrometer-registry-prometheus",
         "io.micrometer:micrometer-registry-influx"
       ],
-      // we don't use the 'monthly' preset because that only fires on the first day of the month
-      // when there might already other PRs open
       "schedule": "on the 7th through 8th day of the month"
+    },
+    {
+      "groupName": "Update GTFS API code generation in a single PR",
+      "matchFiles": ["src/main/java/org/opentripplanner/apis/gtfs/generated/package.json"],
+      "reviewers": ["optionsome", "leonardehrenfried"],
+      "schedule": "on the 11th through 12th day of the month"
     },
     {
       "description": "in order to keep review burden low, don't update these quite so frequently",
@@ -125,6 +124,7 @@
       ]
     },
     {
+      "groupName": "Automerge mkdocs in a single PR",
       "description": "automerge mkdocs-material every quarter",
       "matchPackageNames": [
         "mkdocs",

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/img/otp-logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OTP Debug Client</title>
-    <script type="module" crossorigin src="https://cdn.jsdelivr.net/gh/opentripplanner/debug-client-assets@main/2024/08/2024-08-01T06:45/assets/index-BZBgdA2H.js"></script>
-    <link rel="stylesheet" crossorigin href="https://cdn.jsdelivr.net/gh/opentripplanner/debug-client-assets@main/2024/08/2024-08-01T06:45/assets/index-DAapFGZ4.css">
+    <script type="module" crossorigin src="https://cdn.jsdelivr.net/gh/opentripplanner/debug-client-assets@main/2024/08/2024-08-08T10:11/assets/index-D4y6QGdo.js"></script>
+    <link rel="stylesheet" crossorigin href="https://cdn.jsdelivr.net/gh/opentripplanner/debug-client-assets@main/2024/08/2024-08-08T10:11/assets/index-DAapFGZ4.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
@@ -135,7 +135,13 @@ class EnglishNgramAnalyzerTest {
     assertEquals(List.of(expected), result);
   }
 
-  public List<String> tokenize(String text) {
+  @Test
+  void wordBoundary() {
+    var result = tokenize("1stst");
+    assertEquals(List.of("1sts", "1stst", "stst"), result);
+  }
+
+  private List<String> tokenize(String text) {
     try (var analyzer = new EnglishNGramAnalyzer()) {
       List<String> result;
       TokenStream tokenStream;

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
@@ -82,6 +82,40 @@ class EnglishNgramAnalyzerTest {
     );
   }
 
+  @Test
+  void ampersand() throws IOException {
+    var analyzer = new EnglishNGramAnalyzer();
+    List<String> result = analyze("Meridian Ave N & N 148th St", analyzer);
+
+    assertEquals(
+      List.of(
+        "Meri",
+        "Merid",
+        "Meridi",
+        "Meridia",
+        "Meridian",
+        "erid",
+        "eridi",
+        "eridia",
+        "eridian",
+        "ridi",
+        "ridia",
+        "ridian",
+        "idia",
+        "idian",
+        "dian",
+        "Av",
+        "N",
+        "N",
+        "148t",
+        "148th",
+        "48th",
+        "St"
+      ),
+      result
+    );
+  }
+
   public List<String> analyze(String text, Analyzer analyzer) throws IOException {
     List<String> result = new ArrayList<>();
     TokenStream tokenStream = analyzer.tokenStream("name", text);

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
@@ -18,6 +17,7 @@ class EnglishNgramAnalyzerTest {
     var analyzer = new EnglishNGramAnalyzer();
     List<String> result = analyze("Alexanderplatz", analyzer);
 
+    //System.out.println(result.stream().collect(Collectors.joining("\",\"", "\"", "\"")));
     assertEquals(
       List.of(
         "Ale",
@@ -99,7 +99,6 @@ class EnglishNgramAnalyzerTest {
     var analyzer = new EnglishNGramAnalyzer();
     List<String> result = analyze("Meridian Ave N & N 148th St", analyzer);
 
-    System.out.println(result.stream().collect(Collectors.joining("\",\"", "\"", "\"")));
     assertEquals(
       List.of(
         "Mer",

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/EnglishNgramAnalyzerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
@@ -17,9 +18,9 @@ class EnglishNgramAnalyzerTest {
     var analyzer = new EnglishNGramAnalyzer();
     List<String> result = analyze("Alexanderplatz", analyzer);
 
-    //System.out.println(result.stream().collect(Collectors.joining("\",\"", "\"", "\"")));
     assertEquals(
       List.of(
+        "Ale",
         "Alex",
         "Alexa",
         "Alexan",
@@ -27,6 +28,7 @@ class EnglishNgramAnalyzerTest {
         "Alexande",
         "Alexander",
         "Alexanderp",
+        "lex",
         "lexa",
         "lexan",
         "lexand",
@@ -34,6 +36,7 @@ class EnglishNgramAnalyzerTest {
         "lexander",
         "lexanderp",
         "lexanderpl",
+        "exa",
         "exan",
         "exand",
         "exande",
@@ -41,6 +44,7 @@ class EnglishNgramAnalyzerTest {
         "exanderp",
         "exanderpl",
         "exanderpla",
+        "xan",
         "xand",
         "xande",
         "xander",
@@ -48,6 +52,7 @@ class EnglishNgramAnalyzerTest {
         "xanderpl",
         "xanderpla",
         "xanderplat",
+        "and",
         "ande",
         "ander",
         "anderp",
@@ -55,27 +60,34 @@ class EnglishNgramAnalyzerTest {
         "anderpla",
         "anderplat",
         "anderplatz",
+        "nde",
         "nder",
         "nderp",
         "nderpl",
         "nderpla",
         "nderplat",
         "nderplatz",
+        "der",
         "derp",
         "derpl",
         "derpla",
         "derplat",
         "derplatz",
+        "erp",
         "erpl",
         "erpla",
         "erplat",
         "erplatz",
+        "rpl",
         "rpla",
         "rplat",
         "rplatz",
+        "pla",
         "plat",
         "platz",
+        "lat",
         "latz",
+        "atz",
         "Alexanderplatz"
       ),
       result
@@ -87,29 +99,39 @@ class EnglishNgramAnalyzerTest {
     var analyzer = new EnglishNGramAnalyzer();
     List<String> result = analyze("Meridian Ave N & N 148th St", analyzer);
 
+    System.out.println(result.stream().collect(Collectors.joining("\",\"", "\"", "\"")));
     assertEquals(
       List.of(
+        "Mer",
         "Meri",
         "Merid",
         "Meridi",
         "Meridia",
         "Meridian",
+        "eri",
         "erid",
         "eridi",
         "eridia",
         "eridian",
+        "rid",
         "ridi",
         "ridia",
         "ridian",
+        "idi",
         "idia",
         "idian",
+        "dia",
         "dian",
+        "ian",
         "Av",
         "N",
         "N",
+        "148",
         "148t",
         "148th",
+        "48t",
         "48th",
+        "8th",
         "St"
       ),
       result

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -98,6 +98,10 @@ class LuceneIndexTest {
     .withCoordinate(52.52277, 13.41046)
     .build();
 
+  static final RegularStop MERIDIAN_AVE = TEST_MODEL.stop("Meridian Ave N & N 148th").build();
+
+  static final RegularStop MERIDIAN_1 = TEST_MODEL.stop("Meridian N & Spencer").build();
+
   static LuceneIndex index;
 
   static StopClusterMapper mapper;
@@ -113,7 +117,9 @@ class LuceneIndexTest {
         LICHTERFELDE_OST_2,
         WESTHAFEN,
         ARTS_CENTER,
-        ARTHUR
+        ARTHUR,
+        MERIDIAN_AVE,
+        MERIDIAN_1
       )
       .forEach(stopModel::withRegularStop);
     List
@@ -294,6 +300,15 @@ class LuceneIndexTest {
       assertEquals(ALEXANDERPLATZ_STATION.getName().toString(), cluster.primary().name());
       assertEquals(List.of(StopClusterMapper.toAgency(BVG)), cluster.primary().agencies());
       assertEquals("A Publisher", cluster.primary().feedPublisher().name());
+    }
+
+    @Test
+    void numbers() {
+      var result = index
+        .queryStopClusters("Meridian Ave N & N 148")
+        .map(s -> s.primary().name())
+        .toList();
+      assertEquals(List.of("Meridian Ave N & N 148th", "Meridian N & Spencer"), result);
     }
   }
 

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -305,7 +305,15 @@ class LuceneIndexTest {
 
     @ParameterizedTest
     @ValueSource(
-      strings = { "Meridian Ave N & N 148th", "Meridian Ave N & N 148", "Meridian Ave N N 148" }
+      strings = {
+        "Meridian Ave N & N 148th",
+        "Meridian Ave N & N 148",
+        "Meridian Ave N N 148",
+        "Meridian Ave N 148",
+        "Meridian & N 148",
+        "Meridian Ave 148",
+        "Meridian Av 148",
+      }
     )
     void shortTokens(String query) {
       var names = index.queryStopClusters(query).map(c -> c.primary().name()).toList();

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -316,7 +316,7 @@ class LuceneIndexTest {
         "meridian av 148",
       }
     )
-    void shortTokens(String query) {
+    void numericAdjectives(String query) {
       var names = index.queryStopClusters(query).map(c -> c.primary().name()).toList();
       assertEquals(
         Stream.of(MERIDIAN_AVE, MERIDIAN_N2, MERIDIAN_N1).map(s -> s.getName().toString()).toList(),

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -108,21 +108,21 @@ class LuceneIndexTest {
     .stop("Meridian N & Spencer")
     .withId(FeedScopedId.parse("pierce:13268"))
     .withCode("4168")
-    .withCoordinate(47.209366,-122.293999)
+    .withCoordinate(47.209366, -122.293999)
     .build();
 
   static final RegularStop MERIDIAN_N_2 = TEST_MODEL
     .stop("Meridian N & Spencer")
     .withId(FeedScopedId.parse("pierce:30976"))
     .withCode("4169")
-    .withCoordinate(47.209316,-122.293841)
+    .withCoordinate(47.209316, -122.293841)
     .build();
 
   static final RegularStop MERIDIAN_N_3 = TEST_MODEL
     .stop("N 205th St & Meridian Ave N")
     .withId(FeedScopedId.parse("commtrans:490"))
     .withCode("490")
-    .withCoordinate(47.209316,-122.293841)
+    .withCoordinate(47.777632, -122.3346)
     .build();
 
   static LuceneIndex index;
@@ -329,8 +329,14 @@ class LuceneIndexTest {
 
     @Test
     void number() {
-      var names = index.queryStopClusters("Meridian Ave N & N 148").map(c -> c.primary().name()).toList();
-      assertEquals(List.of(MERIDIAN_AVE.getName().toString(), MERIDIAN_N_1.getName().toString()), names);
+      var names = index
+        .queryStopClusters("Meridian Ave N & N 148")
+        .map(c -> c.primary().name())
+        .toList();
+      assertEquals(
+        List.of(MERIDIAN_AVE.getName().toString(), MERIDIAN_N_1.getName().toString()),
+        names
+      );
     }
   }
 

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -259,7 +260,7 @@ class LuceneIndexTest {
     @Test
     void fuzzyStopClusters() {
       var result1 = index.queryStopClusters("arts").map(primaryId()).toList();
-      assertEquals(List.of(ARTS_CENTER.getId()), result1);
+      assertEquals(List.of(ARTS_CENTER.getId(), ARTHUR.getId()), result1);
     }
 
     @Test
@@ -327,14 +328,15 @@ class LuceneIndexTest {
       assertEquals("A Publisher", cluster.primary().feedPublisher().name());
     }
 
-    @Test
-    void number() {
-      var names = index
-        .queryStopClusters("Meridian Ave N & N 148")
-        .map(c -> c.primary().name())
-        .toList();
+    @ParameterizedTest
+    @ValueSource(strings = { "Meridian Ave N & N 148th", "Meridian Ave N & N 148" })
+    void shortTokens(String query) {
+      var names = index.queryStopClusters(query).map(c -> c.primary().name()).toList();
       assertEquals(
-        List.of(MERIDIAN_AVE.getName().toString(), MERIDIAN_N_1.getName().toString()),
+        Stream
+          .of(MERIDIAN_AVE, MERIDIAN_N_3, MERIDIAN_N_1)
+          .map(s -> s.getName().toString())
+          .toList(),
         names
       );
     }

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -98,9 +97,33 @@ class LuceneIndexTest {
     .withCoordinate(52.52277, 13.41046)
     .build();
 
-  static final RegularStop MERIDIAN_AVE = TEST_MODEL.stop("Meridian Ave N & N 148th").build();
+  static final RegularStop MERIDIAN_AVE = TEST_MODEL
+    .stop("Meridian Ave N & N 148th St")
+    .withId(FeedScopedId.parse("kcm:16340"))
+    .withCode("16340")
+    .withCoordinate(47.736145, -122.33445)
+    .build();
 
-  static final RegularStop MERIDIAN_1 = TEST_MODEL.stop("Meridian N & Spencer").build();
+  static final RegularStop MERIDIAN_N_1 = TEST_MODEL
+    .stop("Meridian N & Spencer")
+    .withId(FeedScopedId.parse("pierce:13268"))
+    .withCode("4168")
+    .withCoordinate(47.209366,-122.293999)
+    .build();
+
+  static final RegularStop MERIDIAN_N_2 = TEST_MODEL
+    .stop("Meridian N & Spencer")
+    .withId(FeedScopedId.parse("pierce:30976"))
+    .withCode("4169")
+    .withCoordinate(47.209316,-122.293841)
+    .build();
+
+  static final RegularStop MERIDIAN_N_3 = TEST_MODEL
+    .stop("N 205th St & Meridian Ave N")
+    .withId(FeedScopedId.parse("commtrans:490"))
+    .withCode("490")
+    .withCoordinate(47.209316,-122.293841)
+    .build();
 
   static LuceneIndex index;
 
@@ -118,8 +141,10 @@ class LuceneIndexTest {
         WESTHAFEN,
         ARTS_CENTER,
         ARTHUR,
-        MERIDIAN_AVE,
-        MERIDIAN_1
+        MERIDIAN_N_1,
+        MERIDIAN_N_2,
+        MERIDIAN_N_3,
+        MERIDIAN_AVE
       )
       .forEach(stopModel::withRegularStop);
     List
@@ -303,16 +328,13 @@ class LuceneIndexTest {
     }
 
     @Test
-    void numbers() {
-      var result = index
-        .queryStopClusters("Meridian Ave N & N 148")
-        .map(s -> s.primary().name())
-        .toList();
-      assertEquals(List.of("Meridian Ave N & N 148th", "Meridian N & Spencer"), result);
+    void number() {
+      var names = index.queryStopClusters("Meridian Ave N & N 148").map(c -> c.primary().name()).toList();
+      assertEquals(List.of(MERIDIAN_AVE.getName().toString(), MERIDIAN_N_1.getName().toString()), names);
     }
   }
 
-  private static @Nonnull Function<StopCluster, FeedScopedId> primaryId() {
+  private static Function<StopCluster, FeedScopedId> primaryId() {
     return c -> c.primary().id();
   }
 }

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -329,7 +329,9 @@ class LuceneIndexTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "Meridian Ave N & N 148th", "Meridian Ave N & N 148" })
+    @ValueSource(
+      strings = { "Meridian Ave N & N 148th", "Meridian Ave N & N 148", "Meridian Ave N N 148" }
+    )
     void shortTokens(String query) {
       var names = index.queryStopClusters(query).map(c -> c.primary().name()).toList();
       assertEquals(

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -98,33 +98,9 @@ class LuceneIndexTest {
     .withCoordinate(52.52277, 13.41046)
     .build();
 
-  static final RegularStop MERIDIAN_AVE = TEST_MODEL
-    .stop("Meridian Ave N & N 148th St")
-    .withId(FeedScopedId.parse("kcm:16340"))
-    .withCode("16340")
-    .withCoordinate(47.736145, -122.33445)
-    .build();
-
-  static final RegularStop MERIDIAN_N_1 = TEST_MODEL
-    .stop("Meridian N & Spencer")
-    .withId(FeedScopedId.parse("pierce:13268"))
-    .withCode("4168")
-    .withCoordinate(47.209366, -122.293999)
-    .build();
-
-  static final RegularStop MERIDIAN_N_2 = TEST_MODEL
-    .stop("Meridian N & Spencer")
-    .withId(FeedScopedId.parse("pierce:30976"))
-    .withCode("4169")
-    .withCoordinate(47.209316, -122.293841)
-    .build();
-
-  static final RegularStop MERIDIAN_N_3 = TEST_MODEL
-    .stop("N 205th St & Meridian Ave N")
-    .withId(FeedScopedId.parse("commtrans:490"))
-    .withCode("490")
-    .withCoordinate(47.777632, -122.3346)
-    .build();
+  static final RegularStop MERIDIAN_AVE = TEST_MODEL.stop("Meridian Ave N & N 148th St").build();
+  static final RegularStop MERIDIAN_N1 = TEST_MODEL.stop("Meridian N & Spencer").build();
+  static final RegularStop MERIDIAN_N2 = TEST_MODEL.stop("N 205th St & Meridian Ave N").build();
 
   static LuceneIndex index;
 
@@ -142,9 +118,8 @@ class LuceneIndexTest {
         WESTHAFEN,
         ARTS_CENTER,
         ARTHUR,
-        MERIDIAN_N_1,
-        MERIDIAN_N_2,
-        MERIDIAN_N_3,
+        MERIDIAN_N1,
+        MERIDIAN_N2,
         MERIDIAN_AVE
       )
       .forEach(stopModel::withRegularStop);
@@ -335,10 +310,7 @@ class LuceneIndexTest {
     void shortTokens(String query) {
       var names = index.queryStopClusters(query).map(c -> c.primary().name()).toList();
       assertEquals(
-        Stream
-          .of(MERIDIAN_AVE, MERIDIAN_N_3, MERIDIAN_N_1)
-          .map(s -> s.getName().toString())
-          .toList(),
+        Stream.of(MERIDIAN_AVE, MERIDIAN_N2, MERIDIAN_N1).map(s -> s.getName().toString()).toList(),
         names
       );
     }

--- a/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/geocoder/LuceneIndexTest.java
@@ -235,7 +235,7 @@ class LuceneIndexTest {
     @Test
     void fuzzyStopClusters() {
       var result1 = index.queryStopClusters("arts").map(primaryId()).toList();
-      assertEquals(List.of(ARTS_CENTER.getId(), ARTHUR.getId()), result1);
+      assertEquals(List.of(ARTS_CENTER.getId()), result1);
     }
 
     @Test
@@ -313,6 +313,7 @@ class LuceneIndexTest {
         "Meridian & N 148",
         "Meridian Ave 148",
         "Meridian Av 148",
+        "meridian av 148",
       }
     )
     void shortTokens(String query) {

--- a/src/ext/java/org/opentripplanner/ext/accessibilityscore/DecorateWithAccessibilityScore.java
+++ b/src/ext/java/org/opentripplanner/ext/accessibilityscore/DecorateWithAccessibilityScore.java
@@ -116,7 +116,7 @@ public record DecorateWithAccessibilityScore(double wheelchairMaxSlope)
       .map(leg -> {
         if (leg instanceof ScheduledTransitLeg transitLeg) {
           return transitLeg.withAccessibilityScore(compute(transitLeg));
-        } else if (leg instanceof StreetLeg streetLeg) {
+        } else if (leg instanceof StreetLeg streetLeg && streetLeg.isWalkingLeg()) {
           return streetLeg.withAccessibilityScore(compute(streetLeg));
         } else {
           return leg;

--- a/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
@@ -26,7 +26,7 @@ import org.apache.lucene.analysis.standard.StandardTokenizer;
 class EnglishNGramAnalyzer extends Analyzer {
 
   // matches one or more numbers followed by the English suffixes "st", "nd", "rd", "th"
-  private static final Pattern NUMBER_SUFFIX_PATTERN = Pattern.compile("(\\d+)[st|nd|rd|th]+");
+  private static final Pattern NUMBER_SUFFIX_PATTERN = Pattern.compile("(\\d+)(st|nd|rd|th)\\b");
 
   @Override
   protected TokenStreamComponents createComponents(String fieldName) {

--- a/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
@@ -28,7 +28,7 @@ class EnglishNGramAnalyzer extends Analyzer {
     result = new StopFilter(result, EnglishAnalyzer.ENGLISH_STOP_WORDS_SET);
     result = new PorterStemFilter(result);
     result = new CapitalizationFilter(result);
-    result = new NGramTokenFilter(result, 4, 10, true);
+    result = new NGramTokenFilter(result, 3, 10, true);
     return new TokenStreamComponents(src, result);
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/EnglishNGramAnalyzer.java
@@ -1,14 +1,16 @@
 package org.opentripplanner.ext.geocoder;
 
+import java.util.regex.Pattern;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.LowerCaseFilter;
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.core.LowerCaseFilter;
 import org.apache.lucene.analysis.core.StopFilter;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.analysis.en.EnglishPossessiveFilter;
 import org.apache.lucene.analysis.en.PorterStemFilter;
 import org.apache.lucene.analysis.miscellaneous.CapitalizationFilter;
 import org.apache.lucene.analysis.ngram.NGramTokenFilter;
+import org.apache.lucene.analysis.pattern.PatternReplaceFilter;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
 
 /**
@@ -17,18 +19,25 @@ import org.apache.lucene.analysis.standard.StandardTokenizer;
  * of a stop name can be matched efficiently.
  * <p>
  * For example the query of "exanderpl" will match the stop name "Alexanderplatz".
+ * <p>
+ * It also removes number suffixes in the American street names, like "147th Street", which will
+ * be tokenized to "147 Street".
  */
 class EnglishNGramAnalyzer extends Analyzer {
+
+  // matches one or more numbers followed by the English suffixes "st", "nd", "rd", "th"
+  private static final Pattern NUMBER_SUFFIX_PATTERN = Pattern.compile("(\\d+)[st|nd|rd|th]+");
 
   @Override
   protected TokenStreamComponents createComponents(String fieldName) {
     StandardTokenizer src = new StandardTokenizer();
     TokenStream result = new EnglishPossessiveFilter(src);
     result = new LowerCaseFilter(result);
+    result = new PatternReplaceFilter(result, NUMBER_SUFFIX_PATTERN, "$1", true);
     result = new StopFilter(result, EnglishAnalyzer.ENGLISH_STOP_WORDS_SET);
     result = new PorterStemFilter(result);
     result = new CapitalizationFilter(result);
-    result = new NGramTokenFilter(result, 3, 10, true);
+    result = new NGramTokenFilter(result, 4, 10, true);
     return new TokenStreamComponents(src, result);
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/geocoder/LuceneIndex.java
@@ -288,7 +288,7 @@ public class LuceneIndex implements Serializable {
             }
           });
       } else {
-        var nameParser = new QueryParser(NAME, analyzer);
+        var nameParser = new QueryParser(NAME_NGRAM, analyzer);
         var nameQuery = nameParser.parse(searchTerms);
 
         var ngramNameQuery = new TermQuery(

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
@@ -20,6 +20,7 @@ import org.glassfish.grizzly.http.server.Request;
 import org.opentripplanner.apis.support.TileJson;
 import org.opentripplanner.ext.vectortiles.layers.areastops.AreaStopsLayerBuilder;
 import org.opentripplanner.ext.vectortiles.layers.stations.StationsLayerBuilder;
+import org.opentripplanner.ext.vectortiles.layers.stops.Predicates;
 import org.opentripplanner.ext.vectortiles.layers.stops.StopsLayerBuilder;
 import org.opentripplanner.ext.vectortiles.layers.vehicleparkings.VehicleParkingGroupsLayerBuilder;
 import org.opentripplanner.ext.vectortiles.layers.vehicleparkings.VehicleParkingsLayerBuilder;
@@ -122,7 +123,18 @@ public class VectorTilesResource {
     OtpServerRequestContext context
   ) {
     return switch (layerParameters.type()) {
-      case Stop -> new StopsLayerBuilder(context.transitService(), layerParameters, locale);
+      case Stop -> new StopsLayerBuilder(
+        context.transitService(),
+        layerParameters,
+        locale,
+        Predicates.NO_FILTER
+      );
+      case CurrentServiceWeekStop -> new StopsLayerBuilder(
+        context.transitService(),
+        layerParameters,
+        locale,
+        Predicates.currentServiceWeek(context.transitService())
+      );
       case Station -> new StationsLayerBuilder(context.transitService(), layerParameters, locale);
       case AreaStop -> new AreaStopsLayerBuilder(context.transitService(), layerParameters, locale);
       case VehicleRental -> new VehicleRentalPlacesLayerBuilder(
@@ -154,6 +166,7 @@ public class VectorTilesResource {
 
   public enum LayerType {
     Stop,
+    CurrentServiceWeekStop,
     Station,
     AreaStop,
     VehicleRental,

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/Predicates.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/Predicates.java
@@ -1,0 +1,31 @@
+package org.opentripplanner.ext.vectortiles.layers.stops;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.function.Predicate;
+import org.opentripplanner.apis.gtfs.PatternByServiceDatesFilter;
+import org.opentripplanner.apis.gtfs.model.LocalDateRange;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.service.TransitService;
+
+public class Predicates {
+
+  public static final Predicate<RegularStop> NO_FILTER = x -> true;
+
+  public static Predicate<RegularStop> currentServiceWeek(TransitService transitService) {
+    var serviceDate = LocalDate.now(transitService.getTimeZone());
+    var lastSunday = serviceDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+    var nextSunday = serviceDate.with(TemporalAdjusters.next(DayOfWeek.SUNDAY)).plusDays(1);
+    var filter = new PatternByServiceDatesFilter(
+      new LocalDateRange(lastSunday, nextSunday),
+      transitService
+    );
+
+    return regularStop -> {
+      var patterns = transitService.getPatternsForStop(regularStop);
+      var patternsInCurrentWeek = filter.filterPatterns(patterns);
+      return !patternsInCurrentWeek.isEmpty();
+    };
+  }
+}

--- a/src/main/java/org/opentripplanner/apis/gtfs/PatternByServiceDatesFilter.java
+++ b/src/main/java/org/opentripplanner/apis/gtfs/PatternByServiceDatesFilter.java
@@ -56,6 +56,14 @@ public class PatternByServiceDatesFilter {
     );
   }
 
+  public PatternByServiceDatesFilter(LocalDateRange range, TransitService transitService) {
+    this(
+      range,
+      transitService::getPatternsForRoute,
+      trip -> transitService.getCalendarService().getServiceDatesForServiceId(trip.getServiceId())
+    );
+  }
+
   /**
    * Filter the patterns by the service dates that it operates on.
    */

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/package.json
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/package.json
@@ -10,7 +10,7 @@
   },
   "license": "LGPL-3.0",
   "dependencies": {
-    "@graphql-codegen/add": "5.0.2",
+    "@graphql-codegen/add": "5.0.3",
     "@graphql-codegen/cli": "5.0.2",
     "@graphql-codegen/java": "4.0.1",
     "@graphql-codegen/java-resolvers": "3.0.0",

--- a/src/main/java/org/opentripplanner/apis/gtfs/generated/yarn.lock
+++ b/src/main/java/org/opentripplanner/apis/gtfs/generated/yarn.lock
@@ -699,7 +699,15 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@graphql-codegen/add@5.0.2", "@graphql-codegen/add@^5.0.2":
+"@graphql-codegen/add@5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/add/-/add-5.0.3.tgz#1ede6bac9a93661ed7fa5808b203d079e1b1d215"
+  integrity sha512-SxXPmramkth8XtBlAHu4H4jYcYXM/o3p01+psU+0NADQowA8jtYkK6MW5rV6T+CxkEaNZItfSmZRPgIuypcqnA==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^5.0.3"
+    tslib "~2.6.0"
+
+"@graphql-codegen/add@^5.0.2":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/add/-/add-5.0.2.tgz#71b3ae0465a4537172dddb84531b6967ca5545f2"
   integrity sha512-ouBkSvMFUhda5VoKumo/ZvsZM9P5ZTyDsI8LW18VxSNWOjrTeLXBWHG8Gfaai0HwhflPtCYVABbriEcOmrRShQ==

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayer.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -51,8 +50,6 @@ public class TransitLayer {
 
   private final StopModel stopModel;
 
-  private final ZoneId transitDataZoneId;
-
   private final RaptorRequestTransferCache transferCache;
 
   private ConstrainedTransfersForPatterns constrainedTransfers;
@@ -73,7 +70,6 @@ public class TransitLayer {
       transitLayer.transfersByStopIndex,
       transitLayer.transferService,
       transitLayer.stopModel,
-      transitLayer.transitDataZoneId,
       transitLayer.transferCache,
       transitLayer.constrainedTransfers,
       transitLayer.transferIndexGenerator,
@@ -86,7 +82,6 @@ public class TransitLayer {
     List<List<Transfer>> transfersByStopIndex,
     TransferService transferService,
     StopModel stopModel,
-    ZoneId transitDataZoneId,
     RaptorRequestTransferCache transferCache,
     ConstrainedTransfersForPatterns constrainedTransfers,
     TransferIndexGenerator transferIndexGenerator,
@@ -96,7 +91,6 @@ public class TransitLayer {
     this.transfersByStopIndex = transfersByStopIndex;
     this.transferService = transferService;
     this.stopModel = stopModel;
-    this.transitDataZoneId = transitDataZoneId;
     this.transferCache = transferCache;
     this.constrainedTransfers = constrainedTransfers;
     this.transferIndexGenerator = transferIndexGenerator;
@@ -115,16 +109,6 @@ public class TransitLayer {
    */
   public Collection<TripPatternForDate> getTripPatternsForRunningDate(LocalDate date) {
     return tripPatternsRunningOnDate.getOrDefault(date, List.of());
-  }
-
-  /**
-   * This is the time zone which is used for interpreting all local "service" times (in transfers,
-   * trip schedules and so on). This is the time zone of the internal OTP time - which is used in
-   * logging and debugging. This is independent of the time zone of imported data and of the time
-   * zone used on any API - it can be the same, but it does not need to.
-   */
-  public ZoneId getTransitDataZoneId() {
-    return transitDataZoneId;
   }
 
   public int getStopCount() {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerMapper.java
@@ -103,7 +103,6 @@ public class TransitLayerMapper {
       transferByStopIndex,
       transitService.getTransferService(),
       stopModel,
-      transitService.getTimeZone(),
       transferCache,
       constrainedTransfers,
       transferIndexGenerator,

--- a/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
+++ b/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
@@ -8,7 +8,6 @@ import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 import org.opentripplanner.service.realtimevehicles.RealtimeVehicleRepository;
@@ -35,6 +34,9 @@ public class DefaultRealtimeVehicleService
 
   @Override
   public void setRealtimeVehicles(TripPattern pattern, List<RealtimeVehicle> updates) {
+    if (pattern.getOriginalTripPattern() != null) {
+      pattern = pattern.getOriginalTripPattern();
+    }
     vehicles.put(pattern, List.copyOf(updates));
   }
 
@@ -45,6 +47,9 @@ public class DefaultRealtimeVehicleService
 
   @Override
   public List<RealtimeVehicle> getRealtimeVehicles(@Nonnull TripPattern pattern) {
+    if (pattern.getOriginalTripPattern() != null) {
+      pattern = pattern.getOriginalTripPattern();
+    }
     // the list is made immutable during insertion, so we can safely return them
     return vehicles.getOrDefault(pattern, List.of());
   }

--- a/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
+++ b/src/main/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleService.java
@@ -32,6 +32,11 @@ public class DefaultRealtimeVehicleService
     this.transitService = transitService;
   }
 
+  /**
+   * Stores the relationship between a list of realtime vehicles with a pattern. If the pattern is
+   * a realtime-added one, then the original (scheduled) one is used as the key for the map storing
+   * the information.
+   */
   @Override
   public void setRealtimeVehicles(TripPattern pattern, List<RealtimeVehicle> updates) {
     if (pattern.getOriginalTripPattern() != null) {
@@ -45,6 +50,13 @@ public class DefaultRealtimeVehicleService
     vehicles.remove(pattern);
   }
 
+  /**
+   * Gets the realtime vehicles for a given pattern. If the pattern is a realtime-added one
+   * then the original (scheduled) one is used for the lookup instead, so you receive the correct
+   * result no matter if you use the realtime or static information.
+   *
+   * @see DefaultRealtimeVehicleService#setRealtimeVehicles(TripPattern, List)
+   */
   @Override
   public List<RealtimeVehicle> getRealtimeVehicles(@Nonnull TripPattern pattern) {
     if (pattern.getOriginalTripPattern() != null) {

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/VectorTileConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/VectorTileConfig.java
@@ -12,14 +12,14 @@ import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.opentripplanner.ext.vectortiles.VectorTilesResource;
+import org.opentripplanner.ext.vectortiles.VectorTilesResource.LayerType;
 import org.opentripplanner.inspector.vector.LayerParameters;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
-public class VectorTileConfig
-  implements VectorTilesResource.LayersParameters<VectorTilesResource.LayerType> {
+public class VectorTileConfig implements VectorTilesResource.LayersParameters<LayerType> {
 
   public static final VectorTileConfig DEFAULT = new VectorTileConfig(List.of(), null, null);
-  private final List<LayerParameters<VectorTilesResource.LayerType>> layers;
+  private final List<LayerParameters<LayerType>> layers;
 
   @Nullable
   private final String basePath;
@@ -28,7 +28,7 @@ public class VectorTileConfig
   private final String attribution;
 
   VectorTileConfig(
-    Collection<? extends LayerParameters<VectorTilesResource.LayerType>> layers,
+    Collection<? extends LayerParameters<LayerType>> layers,
     @Nullable String basePath,
     @Nullable String attribution
   ) {
@@ -38,7 +38,7 @@ public class VectorTileConfig
   }
 
   @Override
-  public List<LayerParameters<VectorTilesResource.LayerType>> layers() {
+  public List<LayerParameters<LayerType>> layers() {
     return layers;
   }
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapperTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapperTest.java
@@ -237,7 +237,6 @@ public class RaptorPathToItineraryMapperTest {
       null,
       null,
       null,
-      null,
       null
     );
   }

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayerTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayerTest.java
@@ -65,7 +65,6 @@ class TransitLayerTest {
       null,
       null,
       null,
-      null,
       null
     );
     var runningOnDate = transitLayer.getTripPatternsRunningOnDateCopy(date);
@@ -89,7 +88,6 @@ class TransitLayerTest {
     var tripPatterns = List.of(tripPatternForDate);
     var transitLayer = new TransitLayer(
       Map.of(date, tripPatterns),
-      null,
       null,
       null,
       null,
@@ -124,7 +122,6 @@ class TransitLayerTest {
       null,
       null,
       null,
-      null,
       null
     );
     var startingOnDate = transitLayer.getTripPatternsOnServiceDateCopy(date);
@@ -147,7 +144,6 @@ class TransitLayerTest {
     );
     var transitLayer = new TransitLayer(
       Map.of(runningDate, List.of(tripPatternForDate)),
-      null,
       null,
       null,
       null,
@@ -181,7 +177,6 @@ class TransitLayerTest {
         entry(firstRunningDate, List.of(tripPatternForDate)),
         entry(secondRunningDate, List.of(tripPatternForDate))
       ),
-      null,
       null,
       null,
       null,

--- a/src/test/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleServiceTest.java
+++ b/src/test/java/org/opentripplanner/service/realtimevehicles/internal/DefaultRealtimeVehicleServiceTest.java
@@ -1,0 +1,55 @@
+package org.opentripplanner.service.realtimevehicles.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.framework.geometry.WgsCoordinate.GREENWICH;
+import static org.opentripplanner.transit.model._data.TransitModelForTest.route;
+import static org.opentripplanner.transit.model._data.TransitModelForTest.tripPattern;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.service.realtimevehicles.model.RealtimeVehicle;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.network.StopPattern;
+import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.TransitModel;
+
+class DefaultRealtimeVehicleServiceTest {
+
+  private static final Route ROUTE = route("r1").build();
+  private static final TransitModelForTest MODEL = TransitModelForTest.of();
+  private static final StopPattern STOP_PATTERN = TransitModelForTest.stopPattern(
+    MODEL.stop("1").build(),
+    MODEL.stop("2").build()
+  );
+  private static final TripPattern ORIGINAL = tripPattern("original", ROUTE)
+    .withStopPattern(STOP_PATTERN)
+    .build();
+  private static final Instant TIME = Instant.ofEpochSecond(1000);
+  private static final List<RealtimeVehicle> VEHICLES = List.of(
+    RealtimeVehicle.builder().withTime(TIME).withCoordinates(GREENWICH).build()
+  );
+
+  @Test
+  void originalPattern() {
+    var service = new DefaultRealtimeVehicleService(new DefaultTransitService(new TransitModel()));
+    service.setRealtimeVehicles(ORIGINAL, VEHICLES);
+    var updates = service.getRealtimeVehicles(ORIGINAL);
+    assertEquals(VEHICLES, updates);
+  }
+
+  @Test
+  void realtimeAddedPattern() {
+    var service = new DefaultRealtimeVehicleService(new DefaultTransitService(new TransitModel()));
+    var realtimePattern = tripPattern("realtime-added", ROUTE)
+      .withStopPattern(STOP_PATTERN)
+      .withOriginalTripPattern(ORIGINAL)
+      .withCreatedByRealtimeUpdater(true)
+      .build();
+    service.setRealtimeVehicles(realtimePattern, VEHICLES);
+    var updates = service.getRealtimeVehicles(ORIGINAL);
+    assertEquals(VEHICLES, updates);
+  }
+}


### PR DESCRIPTION
I will be gone for three weeks but this contains the upstream PRs that are currently under review. During my absence you can test them and give feedback.

The PRs are:

- https://github.com/opentripplanner/OpenTripPlanner/pull/5994: This fixes the problem where vehicle positions are not correctly assigned to patterns that also have TripUpdates that alter the stop pattern, for example by cancelling stops. It already has one approval and @binh-dam-ibigroup is assigned the second reviewer for this one.
- https://github.com/opentripplanner/OpenTripPlanner/pull/5997: Improves the handling of numeric adjectives like "148th" by stripping out the "th" part.
- https://github.com/opentripplanner/OpenTripPlanner/pull/6003: Add ability to filter stops by the current service week. You configure the stop filter like this: https://github.com/leonardehrenfried/otp2-setup/blob/main/portland/router-config.json#L41-L50

