### PR TITLE
PATCO smoke test

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -184,7 +184,7 @@
         <dependency>
             <groupId>org.opentripplanner</groupId>
             <artifactId>otp-client</artifactId>
-            <version>0.1.4</version>
+            <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
         <!-- Provides some shared serializers for Kryo. Introduces transitive dependencies on Trove, and Kryo. -->

--- a/application/src/test/java/org/opentripplanner/smoketest/SeattleSmokeTest.java
+++ b/application/src/test/java/org/opentripplanner/smoketest/SeattleSmokeTest.java
@@ -22,9 +22,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.api.types.Route;
 import org.opentripplanner.client.model.Coordinate;
 import org.opentripplanner.client.model.LegMode;
-import org.opentripplanner.client.model.Route;
 import org.opentripplanner.client.model.TripPlan;
 import org.opentripplanner.client.parameters.TripPlanParameters;
 import org.opentripplanner.client.parameters.TripPlanParametersBuilder;
@@ -112,8 +112,8 @@ public class SeattleSmokeTest {
     );
     var itin = plan.itineraries().getFirst();
     var flexLeg = itin.transitLegs().getFirst();
-    assertEquals(CCSWW_ROUTE, flexLeg.route().name());
-    assertEquals(CCSWW_ROUTE, flexLeg.route().agency().name());
+    assertEquals(CCSWW_ROUTE, flexLeg.route().getLongName());
+    assertEquals(CCSWW_ROUTE, flexLeg.route().getAgency().getName());
   }
 
   @Test
@@ -126,7 +126,9 @@ public class SeattleSmokeTest {
     var walkAndFlex = plan
       .transitItineraries()
       .stream()
-      .filter(i -> i.transitLegs().stream().anyMatch(l -> l.route().name().equals(CCSWW_ROUTE)))
+      .filter(i ->
+        i.transitLegs().stream().anyMatch(l -> l.route().getLongName().equals(CCSWW_ROUTE))
+      )
       .findFirst()
       .get();
     assertEquals(2, walkAndFlex.legs().size());
@@ -140,7 +142,7 @@ public class SeattleSmokeTest {
   public void monorailRoute() throws IOException {
     var modes = SmokeTest.API_CLIENT.routes()
       .stream()
-      .map(Route::mode)
+      .map(Route::getMode)
       .map(Objects::toString)
       .collect(Collectors.toSet());
     // for some reason the monorail feed says its route is of type rail
@@ -160,8 +162,10 @@ public class SeattleSmokeTest {
 
     var first = itineraries.getFirst();
     var leg = first.transitLegs().getFirst();
-    assertThat(Set.of("510", "415")).contains(leg.route().shortName().get());
-    assertThat(Set.of("Sound Transit", "Community Transit")).contains(leg.route().agency().name());
+    assertThat(Set.of("510", "415")).contains(leg.route().getShortName());
+    assertThat(Set.of("Sound Transit", "Community Transit")).contains(
+      leg.route().getAgency().getName()
+    );
 
     var stop = leg.from().stop().get();
     assertEquals("Olive Way & 6th Ave", stop.name());

--- a/application/src/test/java/org/opentripplanner/smoketest/SeptaSmokeTest.java
+++ b/application/src/test/java/org/opentripplanner/smoketest/SeptaSmokeTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.smoketest;
 
 import static org.opentripplanner.client.model.RequestMode.BICYCLE_RENT;
+import static org.opentripplanner.client.model.RequestMode.SUBWAY;
 import static org.opentripplanner.client.model.RequestMode.TRANSIT;
 import static org.opentripplanner.client.model.RequestMode.WALK;
 
@@ -29,6 +30,9 @@ public class SeptaSmokeTest {
 
   Coordinate pierceStreet = new Coordinate(39.93014, -75.18047);
   Coordinate templeUniversity = new Coordinate(39.98069, -75.14886);
+
+  Coordinate locustStreet = new Coordinate(39.94776, -75.16757);
+  Coordinate franklinSquare = new Coordinate(39.95517, -75.15113);
 
   @Test
   public void routeFromAirportToNorthPhiladelphia() {
@@ -72,6 +76,14 @@ public class SeptaSmokeTest {
     SmokeTest.basicRouteTest(
       new SmokeTestRequest(pierceStreet, templeUniversity, Set.of(BICYCLE_RENT)),
       List.of("WALK", "BICYCLE", "WALK")
+    );
+  }
+
+  @Test
+  public void patco() {
+    SmokeTest.basicRouteTest(
+      new SmokeTestRequest(locustStreet, franklinSquare, Set.of(SUBWAY)),
+      List.of("WALK", "SUBWAY", "WALK")
     );
   }
 }

--- a/smoke-tests/septa/build-config.json
+++ b/smoke-tests/septa/build-config.json
@@ -13,7 +13,7 @@
     {
       "type": "gtfs",
       "source": "https://www.ridepatco.org/developers/PortAuthorityTransitCorporation.zip",
-      "feedId": "septa-bus"
+      "feedId": "patco"
     }
   ],
   "fares": "combine-interlined-legs"

--- a/smoke-tests/septa/build-config.json
+++ b/smoke-tests/septa/build-config.json
@@ -9,6 +9,11 @@
       "type": "gtfs",
       "source": "https://www3.septa.org/developer/google_bus.zip",
       "feedId": "septa-bus"
+    },
+    {
+      "type": "gtfs",
+      "source": "https://www.ridepatco.org/developers/PortAuthorityTransitCorporation.zip",
+      "feedId": "septa-bus"
     }
   ],
   "fares": "combine-interlined-legs"


### PR DESCRIPTION
This adds a smoke test for PATCO which uses frequencies.txt. It will fail until the next upstream merge where this feature will be fixed.